### PR TITLE
Extract the iface name from the lease file name

### DIFF
--- a/probert/network.py
+++ b/probert/network.py
@@ -447,7 +447,10 @@ class Network():
                         # neworkd
                         nm_lease = parse_networkd_lease_file(lease_f.read())
                     if nm_lease:
-                        nm_lease["interface"] = socket.if_indextoname(int(index))
+                        # lease file names are
+                        # 'internal[6]-<uuid>-<iface_name>.lease'
+                        iface_name = index.split('-').pop().split('.')[0]
+                        nm_lease["interface"] = iface_name
                         self._dhcp_leases.append(nm_lease)
 
         return self._dhcp_leases


### PR DESCRIPTION
NetworkManager lease files use are named using a specific format which includes the name of the interface. Use that to get the string representation of the interface rather than indexing it from some system service.

NOTE: This patch is already included in the 0.0.11~xenial+ppa1 version in the PPA.

Fixes: LP #1634536?
