### PR TITLE
almost total rewrite of Python parts of network probing

### DIFF
--- a/probert/network.py
+++ b/probert/network.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import abc
 import ipaddress
+import jsonschema
 import logging
 import os
 import socket
@@ -44,7 +46,121 @@ IFF_AUTOMEDIA = 0x4000         # Auto media select active.
 
 IFA_F_PERMANENT = 0x80
 
-def _compute_type(iface):
+BOND_MODES = [
+    "balance-rr",
+    "active-backup",
+    "balance-xor",
+    "broadcast",
+    "802.3ad",
+    "balance-tlb",
+    "balance-alb",
+    ]
+
+# This json schema describes the links as they are serialized onto
+# disk by probert --network. It also describes the format of some of
+# the attributes of Link instances.
+link_schema = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "link",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["addresses", "udev_data", "netlink_data", "type", "bond", "bridge"],
+    "properties": {
+        "addresses": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "address": {"type": "string"},
+                    "ip": {"type": "string"},
+                    "family": {"type": "integer"},
+                    "source": {"type": "string"},
+                    "scope": {"type": "string"},
+                    },
+                },
+            },
+        "type": {
+            "type": "string",
+            #"enum": ["eth", "wlan", "bridge", "vlan"], # there are more
+            },
+        "bond": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "is_master": {"type": "boolean"},
+                "is_slave": {"type": "boolean"},
+                "slaves": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    },
+                "mode": {
+                    "oneOf": [
+                        {"type": "string", "enum": BOND_MODES},
+                        {"type": "null"},
+                        ],
+                    },
+                },
+            },
+        "udev_data": {
+            "type": "object",
+            "properties": {
+                "attrs": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "null"},
+                            ],
+                        },
+                    },
+                },
+            "additionalProperties": {
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "null"},
+                    ],
+                },
+            },
+        "netlink_data": {
+            "type": "object",
+            "properties": {
+                "ifindex": {"type": "integer"},
+                "flags": {"type": "integer"},
+                "arptype": {"type": "integer"},
+                "family": {"type": "integer"},
+                "name": {"type": "string"},
+                },
+            },
+        "bridge": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "is_bridge": {"type": "boolean"},
+                "is_port": {"type": "boolean"},
+                "interfaces": {"type": "array", "items": {"type": "string"}},
+                "options": {  # /sys/class/net/brX/bridge/<options key>
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                    },
+                },
+            },
+        "wlan": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "ssid": {"type": ["null", "string"]},
+                "visible_ssids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    },
+                "scan_state": {"type": ["null", "string"]},
+                },
+            },
+        },
+    }
+
+def _compute_type(iface, arptype):
     if not iface:
         return '???'
 
@@ -55,9 +171,7 @@ def _compute_type(iface):
 
     DEV_TYPE = '???'
 
-    with open(os.path.join(sysfs_path, 'type')) as t:
-        type_value = t.read().split('\n')[0]
-    if type_value == '1':
+    if arptype == 1:
         DEV_TYPE = 'eth'
         if os.path.isdir(os.path.join(sysfs_path, 'wireless')) or \
            os.path.islink(os.path.join(sysfs_path, 'phy80211')):
@@ -74,32 +188,32 @@ def _compute_type(iface):
                 os.path.join('/sys/devices/virtual/net', iface)):
             if iface.startswith('dummy'):
                 DEV_TYPE = 'dummy'
-    elif type_value == '24':  # firewire ;; IEEE 1394 - RFC 2734
+    elif arptype == 24:  # firewire ;; IEEE 1394 - RFC 2734
         DEV_TYPE = 'eth'
-    elif type_value == '32':  # InfiniBand
+    elif arptype == 32:  # InfiniBand
         if os.path.isdir(os.path.join(sysfs_path, 'bonding')):
             DEV_TYPE = 'bond'
         elif os.path.isdir(os.path.join(sysfs_path, 'create_child')):
             DEV_TYPE = 'ib'
         else:
             DEV_TYPE = 'ibchild'
-    elif type_value == '512':
+    elif arptype == 512:
         DEV_TYPE = 'ppp'
-    elif type_value == '768':
+    elif arptype == 768:
         DEV_TYPE = 'ipip'      # IPIP tunnel
-    elif type_value == '769':
+    elif arptype == 769:
         DEV_TYPE = 'ip6tnl'   # IP6IP6 tunnel
-    elif type_value == '772':
+    elif arptype == 772:
         DEV_TYPE = 'lo'
-    elif type_value == '776':
+    elif arptype == 776:
         DEV_TYPE = 'sit'      # sit0 device - IPv6-in-IPv4
-    elif type_value == '778':
+    elif arptype == 778:
         DEV_TYPE = 'gre'      # GRE over IP
-    elif type_value == '783':
+    elif arptype == 783:
         DEV_TYPE = 'irda'     # Linux-IrDA
-    elif type_value == '801':
+    elif arptype == 801:
         DEV_TYPE = 'wlan_aux'
-    elif type_value == '65534':
+    elif arptype == 65534:
         DEV_TYPE = 'tun'
 
     if iface.startswith('ippp') or iface.startswith('isdn'):
@@ -114,6 +228,180 @@ def _compute_type(iface):
     return DEV_TYPE
 
 
+def _get_bonding(ifname, flags):
+
+    def _iface_is_master():
+        return bool(flags & IFF_MASTER) != 0
+
+    def _iface_is_slave():
+        return bool(flags & IFF_SLAVE) != 0
+
+    def _get_slave_iface_list():
+        try:
+            if _iface_is_master():
+                bond = open('/sys/class/net/%s/bonding/slaves' % ifname).read()
+                return bond.split()
+            else:
+                return []
+        except IOError:
+            return []
+
+    def _get_bond_mode():
+        try:
+            if _iface_is_master():
+                bond_mode = \
+                    open('/sys/class/net/%s/bonding/mode' % ifname).read()
+                return bond_mode.split()
+        except IOError:
+            return None
+
+    mode = _get_bond_mode()
+    if mode:
+        mode_name = mode[0]
+    else:
+        mode_name = None
+    return {
+        'is_master': _iface_is_master(),
+        'is_slave': _iface_is_slave(),
+        'slaves': _get_slave_iface_list(),
+        'mode': mode_name
+    }
+
+
+def _get_bridging(ifname):
+
+    def _iface_is_bridge():
+        bridge_path = os.path.join('/sys/class/net', ifname, 'bridge')
+        return os.path.exists(bridge_path)
+
+    def _iface_is_bridge_port():
+        bridge_port = os.path.join('/sys/class/net', ifname, 'brport')
+        return os.path.exists(bridge_port)
+
+    def _get_bridge_iface_list():
+        if _iface_is_bridge():
+            bridge_path = os.path.join('/sys/class/net', ifname, 'brif')
+            return os.listdir(bridge_path)
+        return []
+
+    def _get_bridge_options():
+        skip_attrs = set(['flush', 'bridge'])  # needs root access, not useful
+
+        if _iface_is_bridge():
+            bridge_path = os.path.join('/sys/class/net', ifname, 'bridge')
+        elif _iface_is_bridge_port():
+            bridge_path = os.path.join('/sys/class/net', ifname, 'brport')
+        else:
+            return {}
+
+        options = {}
+        for bridge_attr_name in os.listdir(bridge_path):
+            if bridge_attr_name in skip_attrs:
+                continue
+            bridge_attr_file = os.path.join(bridge_path, bridge_attr_name)
+            with open(bridge_attr_file) as bridge_attr:
+                options[bridge_attr_name] = bridge_attr.read().strip()
+
+        return options
+
+    return {
+        'is_bridge': _iface_is_bridge(),
+        'is_port': _iface_is_bridge_port(),
+        'interfaces': _get_bridge_iface_list(),
+        'options': _get_bridge_options(),
+    }
+
+
+def netlink_attr(attr):
+    def get(obj):
+        return obj.netlink_data[attr]
+    return property(get)
+
+
+def udev_attr(keys, missing):
+    def get(obj):
+        for k in keys:
+            if k in obj.udev_data:
+                return obj.udev_data[k]
+        return missing
+    return property(get)
+
+
+class Link:
+
+    @classmethod
+    def from_probe_data(cls, netlink_data, udev_data):
+        # This is a bit of a hack, but sometimes the interface has
+        # already been renamed by udev by the time we get here, so we
+        # can't use netlink_data['name'] to go poking about in
+        # /sys/class/net.
+        name = socket.if_indextoname(netlink_data['ifindex'])
+        return cls(
+            addresses={},
+            type=_compute_type(name, netlink_data['arptype']),
+            udev_data=udev_data,
+            netlink_data=netlink_data,
+            bond=_get_bonding(name, netlink_data['flags']),
+            bridge=_get_bridging(name))
+
+    @classmethod
+    def from_saved_data(cls, link_data):
+        address_objs = {}
+        for addr in link_data['addresses']:
+            a = Address.from_saved_data(addr)
+            address_objs[str(a.ip)] = a
+        link_data['addresses'] = address_objs
+        return cls(**link_data)
+
+    def __init__(self, addresses, type, udev_data, netlink_data, bond, bridge, wlan=None):
+        self.addresses = addresses
+        self.type = type
+        self.udev_data = udev_data
+        self.netlink_data = netlink_data
+        self.bond = bond
+        self.bridge = bridge
+        self.wlan = wlan
+
+    def serialize(self):
+        r = {
+            "addresses": [a.serialize() for a in self.addresses.values()],
+            "udev_data": self.udev_data,
+            "type": self.type,
+            "netlink_data": self.netlink_data,
+            "bond": self.bond,
+            "bridge": self.bridge,
+            }
+        if self.wlan is not None:
+            r["wlan"] = self.wlan
+        jsonschema.validate(r, link_schema)
+        return r
+
+    flags = netlink_attr("flags")
+    ifindex = netlink_attr("ifindex")
+    name = netlink_attr("name")
+    hwaddr = property(lambda self:self.udev_data['attrs']['address'])
+
+    vendor = udev_attr(['ID_VENDOR_FROM_DATABASE', 'ID_VENDOR', 'ID_VENDOR_ID'], "Unknown Vendor")
+    model = udev_attr(['ID_MODEL_FROM_DATABASE', 'ID_MODEL', 'ID_MODEL_ID'], "Unknown Model")
+    driver = udev_attr(['ID_NET_DRIVER', 'ID_USB_DRIVER'], "Unknown Driver")
+    devpath = udev_attr(['DEVPATH'], "Unknown devpath")
+
+    hwaddr = property(lambda self:self.udev_data['attrs']['address'])
+
+    # This is the logic ip from iproute2 uses to determine whether
+    # to show NO-CARRIER or not. It only really makes sense for a
+    # wired connection.
+    is_connected = property(lambda self:(not (self.flags & IFF_UP)) or (self.flags & IFF_RUNNING))
+    is_virtual = property(lambda self:self.devpath.startswith('/devices/virtual/'))
+
+    @property
+    def ssid(self):
+        if self.wlan:
+            return self.wlan['ssid']
+        else:
+            return None
+
+
 _scope_str = {
     0: 'global',
 	200: "site",
@@ -125,240 +413,98 @@ _scope_str = {
 
 class Address:
 
-    def __init__(self, netlink_data):
-        self.address = ipaddress.ip_interface(netlink_data['local'].decode('latin-1'))
+    def __init__(self, address, family, source, scope):
+        self.address = ipaddress.ip_interface(address)
         self.ip = self.address.ip
-        self.family = netlink_data['family']
+        self.family = family
+        self.source = source
+        self.scope = scope
+
+    def serialize(self):
+        return {
+            'source': self.source,
+            'family': self.family,
+            'address': str(self.address),
+            'scope': self.scope,
+            }
+
+    @classmethod
+    def from_probe_data(cls, netlink_data):
+        address = netlink_data['local'].decode('latin-1')
+        family = netlink_data['family']
         if netlink_data.get('flags', 0) & IFA_F_PERMANENT:
-            self.source = 'static'
+            source = 'static'
         else:
-            self.source = 'dhcp'
+            source = 'dhcp'
         scope = netlink_data['scope']
-        self.scope = str(_scope_str.get(scope))
+        scope = str(_scope_str.get(scope, scope))
+        return cls(address, family, source, scope)
+
+    @classmethod
+    def from_saved_data(cls, link_data):
+        return Address(**link_data)
 
 
-class NetworkInfo:
-    def __init__(self, netlink_data, udev_data):
-        self.update_from_netlink_data(netlink_data)
-        self.udev_data = udev_data
+class NetworkObserver(abc.ABC):
+    """A NetworkObserver observes the network state.
 
-        self.hwaddr = self.udev_data['attrs']['address']
+    It calls methods on a NetworkEventReceiver in response to changes.
+    """
 
-        self.type = _compute_type(self.name)
-        self.addresses = {}
-        self.bond = self._get_bonding()
-        self.bridge = self._get_bridging()
+    @abc.abstractmethod
+    def start(self):
+        pass
 
-
-        # Wifi only things (set from UdevObserver.wlan_event)
-        self.ssid = None
-        self.ssids = []
-        self.scan_state = None
-
-    def update_from_netlink_data(self, netlink_data):
-        self.netlink_data = netlink_data
-        self.flags = self.netlink_data['flags']
-        self.ifindex = self.netlink_data['ifindex']
-        try:
-            self.name = socket.if_indextoname(self.ifindex)
-        except OSError:
-            self.name = "???"
-        # This is the logic ip from iproute2 uses to determine whether
-        # to show NO-CARRIER or not. It only really makes sense for a
-        # wired connection.
-        self.is_connected = (not (self.flags & IFF_UP)) or (self.flags & IFF_RUNNING)
+    @abc.abstractmethod
+    def data_ready(self, fd):
+        pass
 
 
-    def _get_hwvalues(self, keys, missing='Unknown value'):
-        for key in keys:
-            try:
-                return self.udev_data[key]
-            except KeyError:
-                pass
+class NetworkEventReceiver(abc.ABC):
+    """NetworkEventReceiver has methods called on it in response to network chagnes."""
 
-        return missing
+    @abc.abstractmethod
+    def new_link(self, ifindex, link):
+        pass
 
-    @property
-    def vendor(self):
-        keys = [
-            'ID_VENDOR_FROM_DATABASE',
-            'ID_VENDOR',
-            'ID_VENDOR_ID'
-        ]
-        return self._get_hwvalues(keys=keys, missing='Unknown Vendor')
+    @abc.abstractmethod
+    def update_link(self, ifindex):
+        pass
 
-    @property
-    def model(self):
-        keys = [
-            'ID_MODEL_FROM_DATABASE',
-            'ID_MODEL',
-            'ID_MODEL_ID'
-        ]
-        return self._get_hwvalues(keys=keys, missing='Unknown Model')
+    @abc.abstractmethod
+    def del_link(self, ifindex):
+        pass
 
-    @property
-    def driver(self):
-        keys = [
-            'ID_NET_DRIVER',
-            'ID_USB_DRIVER',
-        ]
-        return self._get_hwvalues(keys=keys, missing='Unknown Driver')
-
-    @property
-    def devpath(self):
-        keys = ['DEVPATH']
-        return self._get_hwvalues(keys=keys, missing='Unknown devpath')
-
-    @property
-    def is_virtual(self):
-        return self.devpath.startswith('/devices/virtual/')
-
-    def _iface_is_master(self):
-        return bool(self.flags & IFF_MASTER) != 0
-
-    def _iface_is_slave(self):
-        return bool(self.flags & IFF_SLAVE) != 0
-
-    def _get_slave_iface_list(self):
-        try:
-            if self._iface_is_master():
-                bond = open('/sys/class/net/%s/bonding/slaves' % self.name).read()
-                return bond.split()
-        except IOError:
-            return []
-
-    def _get_bond_mode(self, ):
-        try:
-            if self._iface_is_master():
-                bond_mode = \
-                    open('/sys/class/net/%s/bonding/mode' % self.name).read()
-                return bond_mode.split()
-        except IOError:
-            return None
-
-    def _get_bonding(self):
-        ''' return bond structure for iface
-           'bond': {
-              'is_master': [True|False]
-              'is_slave': [True|False]
-              'slaves': []
-              'mode': in BONDING_MODES.keys() or BONDING_MODES.values()
-            }
-        '''
-        is_master = self._iface_is_master()
-        is_slave = self._iface_is_slave()
-        slaves = self._get_slave_iface_list()
-        mode = self._get_bond_mode()
-        if mode:
-            mode_name = mode[0]
-        else:
-            mode_name = None
-        bond = {
-            'is_master': is_master,
-            'is_slave': is_slave,
-            'slaves': slaves,
-            'mode': mode_name
-        }
-        return bond
-
-    def _iface_is_bridge(self, ):
-        bridge_path = os.path.join('/sys/class/net', self.name, 'bridge')
-        return os.path.exists(bridge_path)
-
-    def _iface_is_bridge_port(self):
-        bridge_port = os.path.join('/sys/class/net', self.name, 'brport')
-        return os.path.exists(bridge_port)
-
-    def _get_bridge_iface_list(self):
-        if self._iface_is_bridge():
-            bridge_path = os.path.join('/sys/class/net', self.name, 'brif')
-            return os.listdir(bridge_path)
-
-        return []
-
-    def _get_bridge_options(self):
-        invalid_attrs = ['flush', 'bridge']  # needs root access, not useful
-
-        options = {}
-        if self._iface_is_bridge():
-            bridge_path = os.path.join('/sys/class/net', self.name, 'bridge')
-        elif self._iface_is_bridge_port():
-            bridge_path = os.path.join('/sys/class/net', self.name, 'brport')
-        else:
-            return options
-
-        for bridge_attr_name in [attr for attr in os.listdir(bridge_path)
-                                 if attr not in invalid_attrs]:
-            bridge_attr_file = os.path.join(bridge_path, bridge_attr_name)
-            with open(bridge_attr_file) as bridge_attr:
-                options[bridge_attr_name] = bridge_attr.read().strip()
-
-        return options
-
-    def _get_bridging(self):
-        ''' return bridge structure for iface
-           'bridge': {
-              'is_bridge': [True|False],
-              'is_port': [True|False],
-              'interfaces': [],
-              'options': {  # /sys/class/net/brX/bridge/<options key>
-                  'sysfs_key': sysfs_value
-              },
-            }
-        '''
-        is_bridge = self._iface_is_bridge()
-        is_port = self._iface_is_bridge_port()
-        interfaces = self._get_bridge_iface_list()
-        options = self._get_bridge_options()
-        bridge = {
-            'is_bridge': is_bridge,
-            'is_port': is_port,
-            'interfaces': interfaces,
-            'options': options,
-        }
-        return bridge
+    @abc.abstractmethod
+    def route_change(self, action, data):
+        pass
 
 
-class Network:
+class TrivialEventReceiver(NetworkEventReceiver):
 
-    def probe(self):
-        results = {}
-        observer = UdevObserver()
-        observer.start()
-        for l in observer.links.values():
-            addresses = []
-            for a in l.addresses.values():
-                addresses.append({
-                    'ip': str(a.ip),
-                    'address': str(a.address),
-                    'family': a.family,
-                    'source': a.source,
-                    'scope': a.scope,
-                    })
-            results[l.name] = {
-                'udev_data' : l.udev_data,
-                'hwaddr' : l.hwaddr,
-                'type' : l.type,
-                'addresses' : addresses,
-            }
-            if l.type == 'wlan':
-                results[l.name]['ssid'] = l.ssid.decode("utf-8")
-                results[l.name]['ssids'] = l.ssids
-                results[l.name]['scan_state'] = l.scan_state
-            if l.type == 'bridge':
-                results[l.name]['bridge'] = l.bridge
-            if l.type == 'bond':
-                results[l.name]['bond'] = l.bond
+    def new_link(self, ifindex, link):
+        pass
 
-        print(results)
-        return results
+    def update_link(self, ifindex):
+        pass
+
+    def del_link(self, ifindex):
+        pass
+
+    def route_change(self, action, data):
+        pass
 
 
-class UdevObserver:
+class UdevObserver(NetworkObserver):
+    """Use udev/netlink to observe network changes."""
 
-    def __init__(self):
-        self.links = {}
+    def __init__(self, receiver=None):
+        self._links = {}
         self.context = pyudev.Context()
+        if receiver is None:
+            receiver = TrivialEventReceiver()
+        assert isinstance(receiver, NetworkEventReceiver)
+        self.receiver = receiver
 
     def start(self):
         self.rtlistener = _rtnetlink.listener(self)
@@ -385,33 +531,33 @@ class UdevObserver:
     def link_change(self, action, data):
         log.debug('link_change %s %s', action, data)
         for k, v in data.items():
-            if isinstance(data, bytes):
-                data[k] = data.decode('utf-8', 'replace')
+            if isinstance(v, bytes):
+                data[k] = v.decode('utf-8', 'replace')
         ifindex = data['ifindex']
         if action == 'DEL':
-            if ifindex in self.links:
-                del self.links[ifindex]
-                self.del_link(ifindex)
+            if ifindex in self._links:
+                del self._links[ifindex]
+                self.receiver.del_link(ifindex)
             return
         if action == 'CHANGE':
-            if ifindex in self.links:
-                dev = self.links[ifindex]
+            if ifindex in self._links:
+                dev = self._links[ifindex]
                 # Trigger a scan when a wlan device goes up
                 # Not sure if this is required as devices seem to scan as soon
                 # as they go up? (in which case this fails with EBUSY, so it's
                 # just spam in the logs).
                 if dev.type == 'wlan' and (not (dev.flags & IFF_UP)) and (data['flags'] & IFF_UP):
                     try:
-                        self.wlan_listener.trigger_scan(ifindex)
+                        self.trigger_scan(ifindex)
                     except RuntimeError:
                         log.exception('on-up trigger_scan failed')
-                dev.update_from_netlink_data(data)
+                dev.netlink_data = data
                 # If a device appears and is immediately renamed, the
                 # initial _compute_type can fail to find the sysfs
                 # directory. Have another go now.
                 if dev.type is None:
                     dev.type = _compute_type(dev.name)
-            self.update_link(ifindex)
+            self.receiver.update_link(ifindex)
             return
         udev_devices = list(self.context.list_devices(IFINDEX=str(ifindex)))
         if len(udev_devices) == 0:
@@ -420,47 +566,54 @@ class UdevObserver:
         udev_device = udev_devices[0]
         udev_data = dict(udev_device)
         udev_data['attrs'] = udev_get_attributes(udev_device)
-        link = NetworkInfo(data, udev_data)
-        self.links[data['ifindex']] = link
-        self.new_link(ifindex, link)
+        link = Link.from_probe_data(data, udev_data)
+        self._links[ifindex] = link
+        self.receiver.new_link(ifindex, link)
 
     def addr_change(self, action, data):
         log.debug('addr_change %s %s', action, data)
-        link = self.links.get(data['ifindex'])
+        link = self._links.get(data['ifindex'])
         if link is None:
             return
         ip = data['local'].decode('latin-1')
         if action == 'DEL':
             link.addresses.pop(ip, None)
             return
-        link.addresses[ip] = Address(data)
+        link.addresses[ip] = Address.from_probe_data(data)
 
     def route_change(self, action, data):
         log.debug('route_change %s %s', action, data)
+        self.receiver.route_change(action, data)
+
+    def trigger_scan(self, ifindex):
+        self.wlan_listener.trigger_scan(ifindex)
 
     def wlan_event(self, arg):
         log.debug('wlan_event %s', arg)
         ifindex = arg['ifindex']
-        if ifindex < 0 or ifindex not in self.links:
+        if ifindex < 0 or ifindex not in self._links:
             return
-        link = self.links[ifindex]
+        link = self._links[ifindex]
         if arg['cmd'] == 'TRIGGER_SCAN':
-            link.scan_state = 'scanning'
+            link.wlan['scan_state'] = 'scanning'
         if arg['cmd'] == 'NEW_SCAN_RESULTS' and 'ssids' in arg:
             ssids = set()
             for (ssid, status) in arg['ssids']:
+                ssid = ssid.decode('utf-8', 'replace')
                 ssids.add(ssid)
                 if status != "no status":
-                    link.ssid = ssid
-            link.ssids = sorted(ssids)
-            link.scan_state = None
-        if arg['cmd'] == 'NEW_INTERFACE' or arg['cmd'] == 'ASSOCIATE':
-            if len(arg.get('ssids', [])) > 0:
-                link.ssid = arg['ssids'][0][0]
+                    link.wlan['ssid'] = ssid
+            link.wlan['visible_ssids'] = sorted(ssids)
+            link.wlan['scan_state'] = None
         if arg['cmd'] == 'NEW_INTERFACE':
+            link.wlan = {
+                'visible_ssids': [],
+                'ssid': None,
+                'scan_state': None,
+            }
             if link.flags & IFF_UP:
                 try:
-                    self.wlan_listener.trigger_scan(ifindex)
+                    self.trigger_scan(ifindex)
                 except RuntimeError: # Can't trigger a scan as non-root, that's OK.
                     log.exception('initial trigger_scan failed')
             else:
@@ -468,17 +621,52 @@ class UdevObserver:
                     self.rtlistener.set_link_flags(ifindex, IFF_UP)
                 except RuntimeError:
                     log.exception('set_link_flags failed')
+        if arg['cmd'] == 'NEW_INTERFACE' or arg['cmd'] == 'ASSOCIATE':
+            if len(arg.get('ssids', [])) > 0:
+                link.wlan['ssid'] = arg['ssids'][0][0].decode('utf-8', 'replace')
         if arg['cmd'] == 'DISCONNECT':
-            link.ssid = None
+            link.wlan['ssid'] = None
 
-    def new_link(self, ifindex, link):
+
+class StoredDataObserver:
+    """A cheaty observer that just pretends the network is in some pre-arranged state."""
+
+    def __init__(self, saved_data, receiver):
+        self.saved_data = saved_data
+        for data in self.saved_data:
+            jsonschema.validate(data, link_schema)
+        self.receiver = receiver
+
+    def start(self):
+        for data in self.saved_data:
+            link = Link.from_saved_data(data)
+            self.receiver.new_link(link.ifindex, link)
+        return []
+
+    def trigger_scan(self, ifindex):
         pass
 
-    def update_link(self, ifindex):
+    def data_ready(self, fd):
         pass
 
-    def del_link(self, ifindex):
-        pass
+
+class NetworkProber:
+
+    def probe(self):
+        class LinkCollectingReceiver(TrivialEventReceiver):
+            def __init__(self):
+                self.all_links = set()
+            def new_link(self, ifindex, link):
+                self.all_links.add(link)
+        collector = LinkCollectingReceiver()
+        observer = UdevObserver(collector)
+        observer.start()
+        results = []
+        for link in collector.all_links:
+            results.append(link.serialize())
+
+        return results
+
 
 
 if __name__ == '__main__':

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from probert.storage import Storage
-from probert.network import Network
+from probert.network import NetworkProber
 
 
 class Prober():
@@ -29,7 +29,7 @@ class Prober():
         self._results['storage'] = Storage().probe()
 
     def probe_network(self):
-        self._results['network'] = Network().probe()
+        self._results['network'] = NetworkProber().probe()
 
     def get_results(self):
         return self._results


### PR DESCRIPTION
Probably too big a change for a single commit but never mind.

Highlights:
 - Less inheritance, more composition (one now passes a "listener" to an
   "observer" rather than subclassing the observer and overriding methods).
 - There's now a way to have probert report a saved network configuration
   rather than always probing the actual system
 - The format of the saved network configuration has changed and now is
   validated against a json schema
 - The NetworkInfo class is gone, replaced by a Link class which is similar
   but (imo) clearer and much more upfront about what data is calculated when
   the class is instantiated vs what is derived later.