### PR TITLE
Feature/export curtin storage types

### DIFF
--- a/bin/probert
+++ b/bin/probert
@@ -31,14 +31,8 @@ def parse_options(argv):
                         help='Probe all hardware types.')
     parser.add_argument('--storage', action='store_true',
                         help='Probe storage hardware.')
-    parser.add_argument('--lvm', action='store_true',
-                        help='Probe for LVM devices.')
     parser.add_argument('--network', action='store_true',
                         help='Probe network hardware.')
-    parser.add_argument('--raid', action='store_true',
-                        help='Probe for RAID devices.')
-    parser.add_argument('--export-config', action='store_true',
-                        help='Print probed data in Curti config format.')
     return parser.parse_args(argv)
 
 
@@ -50,21 +44,15 @@ def main():
     logger.info("Arguments passed: {}".format(sys.argv))
 
     p = prober.Prober()
-    probe_opts = [opts.lvm, opts.network, opts.raid, opts.storage]
+    probe_opts = [opts.network, opts.storage]
     if opts.all or not any(probe_opts):
         p.probe_all()
     if opts.network:
         p.probe_network()
-    if opts.lvm:
-        p.probe_lvm()
-    if opts.raid:
-        p.probe_raid()
     if opts.storage:
         p.probe_storage()
-    if opts.export_config:
-        results = p.export_config()
-    else:
-        results = p.get_results()
+
+    results = p.get_results()
     print(json.dumps(results, indent=4, sort_keys=True))
 
 

--- a/bin/probert
+++ b/bin/probert
@@ -65,7 +65,7 @@ def main():
         results = p.export_config()
     else:
         results = p.get_results()
-    print(json.dumps(results, indent=4, sort_keys=False))
+    print(json.dumps(results, indent=4, sort_keys=True))
 
 
 if __name__ == '__main__':

--- a/bin/probert
+++ b/bin/probert
@@ -31,6 +31,8 @@ def parse_options(argv):
                         help='Probe all hardware types.')
     parser.add_argument('--storage', action='store_true',
                         help='Probe storage hardware.')
+    parser.add_argument('--lvm', action='store_true',
+                        help='Probe for LVM devices.')
     parser.add_argument('--network', action='store_true',
                         help='Probe network hardware.')
     parser.add_argument('--export-config', action='store_true',
@@ -50,6 +52,8 @@ def main():
         p.probe_all()
     if opts.network:
         p.probe_network()
+    if opts.lvm:
+        p.probe_lvm()
     if opts.storage:
         p.probe_storage()
     if opts.export_config:

--- a/bin/probert
+++ b/bin/probert
@@ -35,6 +35,8 @@ def parse_options(argv):
                         help='Probe for LVM devices.')
     parser.add_argument('--network', action='store_true',
                         help='Probe network hardware.')
+    parser.add_argument('--raid', action='store_true',
+                        help='Probe for RAID devices.')
     parser.add_argument('--export-config', action='store_true',
                         help='Print probed data in Curti config format.')
     return parser.parse_args(argv)
@@ -48,12 +50,15 @@ def main():
     logger.info("Arguments passed: {}".format(sys.argv))
 
     p = prober.Prober()
-    if opts.all or (not opts.storage and not opts.network):
+    probe_opts = [opts.lvm, opts.network, opts.raid, opts.storage]
+    if opts.all or not any(probe_opts):
         p.probe_all()
     if opts.network:
         p.probe_network()
     if opts.lvm:
         p.probe_lvm()
+    if opts.raid:
+        p.probe_raid()
     if opts.storage:
         p.probe_storage()
     if opts.export_config:

--- a/bin/probert
+++ b/bin/probert
@@ -33,6 +33,8 @@ def parse_options(argv):
                         help='Probe storage hardware.')
     parser.add_argument('--network', action='store_true',
                         help='Probe network hardware.')
+    parser.add_argument('--export-config', action='store_true',
+                        help='Print probed data in Curti config format.')
     return parser.parse_args(argv)
 
 
@@ -50,7 +52,10 @@ def main():
         p.probe_network()
     if opts.storage:
         p.probe_storage()
-    results = p.get_results()
+    if opts.export_config:
+        results = p.export_config()
+    else:
+        results = p.get_results()
     print(json.dumps(results, indent=4, sort_keys=False))
 
 

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,14 @@ Package: probert
 Architecture: any
 Depends: ${misc:Depends},
          ${python3:Depends},
-         ${shlibs:Depends}
+         ${shlibs:Depends},
+         bcache-tools,
+         lvm2,
+         mdadm,
+         multipath-tools,
+         util-linux,
+         zfsutils-linux
+
 Description: Hardware probing tool
  This package provides a tool for probing host hardware information
  and emitting a JSON report.

--- a/probert/bcache.py
+++ b/probert/bcache.py
@@ -100,6 +100,23 @@ def is_bcache_device(device):
 
 
 def probe(context=None):
+    """Probe the system for bcache devices.  Bcache devices
+       are registered with the kernel upon module load and when
+       devices are hot/cold plugged.  There are two portions to
+       a bcache, the backing device which holds data and the cache
+       device which cached data from the backing device.  A backing
+       device encodes a specific cache_set UUID in the backing device
+       which is used to bind both device in the kernel and create a
+       new block device, bcacheN.
+
+       For each block device which has a bcache superblock embedded,
+       extract and examine the superblock to determine which type of
+       bcache device (backing, caching) and the relevant UUIDs and
+       build (if possible) the pairing of caches to backing.
+
+       This probe reports the devices separately but enough information
+       is included to re-assemble joined bcache devices if desired.
+    """
     backing = {}
     caching = {}
     bcache = {'backing': backing, 'caching': caching}
@@ -117,6 +134,6 @@ def probe(context=None):
             elif is_caching(devpath):
                 caching[bkey] = bconfig
             else:
-                print('WARK: %s is not bcache?' % devpath)
+                log.error('bcache.probe: %s is not bcache' % devpath)
 
     return bcache

--- a/probert/bcache.py
+++ b/probert/bcache.py
@@ -36,7 +36,8 @@ def superblock_asdict(device=None, data=None):
         if not line:
             continue
         values = [val for val in line.split('\t') if val]
-        bcache_super.update({values[0]: values[1]})
+        if len(values) == 2:
+            bcache_super.update({values[0]: values[1]})
 
     return bcache_super
 
@@ -109,7 +110,7 @@ def probe(context=None):
         if is_bcache_device(device):
             devpath = device['DEVNAME']
             sb = superblock_asdict(devpath)
-            bkey = sb['dev.uuid']
+            bkey = sb.get('dev.uuid', 'not available')
             bconfig = {'blockdev': devpath, 'superblock': sb}
             if is_backing(devpath):
                 backing[bkey] = bconfig

--- a/probert/bcache.py
+++ b/probert/bcache.py
@@ -1,0 +1,121 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import subprocess
+
+log = logging.getLogger('probert.bcache')
+
+
+def superblock_asdict(device=None, data=None):
+    """ Convert output from bcache-super-show into a dictionary"""
+
+    if not device and not data:
+        raise ValueError('Supply a device name, or data to parse')
+
+    if not data:
+        cmd = ['bcache-super-show', device]
+        result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL)
+        data = result.stdout.decode('utf-8')
+    bcache_super = {}
+    for line in data.splitlines():
+        if not line:
+            continue
+        values = [val for val in line.split('\t') if val]
+        bcache_super.update({values[0]: values[1]})
+
+    return bcache_super
+
+
+def parse_sb_version(sb_version):
+    """ Convert sb_version string to integer if possible"""
+    try:
+        # 'sb.version': '1 [backing device]'
+        # 'sb.version': '3 [caching device]'
+        version = int(sb_version.split()[0])
+    except (AttributeError, ValueError):
+        log.warning("Failed to parse bcache 'sb.version' field"
+                    " as integer: %s", sb_version)
+        return None
+
+    return version
+
+
+def is_backing(device, superblock=False):
+    """ Test if device is a bcache backing device
+
+    A runtime check for an active bcache backing device is to
+    examine /sys/class/block/<kname>/bcache/label
+
+    However if a device is not active then read the superblock
+    of the device and check that sb.version == 1"""
+
+    if not superblock:
+        sys_block = '/sys/class/block/%s' % os.path.basename(device)
+        bcache_sys_attr = os.path.join(sys_block, 'bcache', 'label')
+        return os.path.exists(bcache_sys_attr)
+    else:
+        bcache_super = superblock_asdict(device=device)
+        sb_version = parse_sb_version(bcache_super['sb.version'])
+        return bcache_super and sb_version == 1
+
+
+def is_caching(device, superblock=False):
+    """ Test if device is a bcache caching device
+
+    A runtime check for an active bcache backing device is to
+    examine /sys/class/block/<kname>/bcache/cache_replacement_policy
+
+    However if a device is not active then read the superblock
+    of the device and check that sb.version == 3"""
+
+    if not superblock:
+        sys_block = '/sys/class/block/%s' % os.path.basename(device)
+        bcache_sys_attr = os.path.join(sys_block, 'bcache',
+                                       'cache_replacement_policy')
+        return os.path.exists(bcache_sys_attr)
+    else:
+        bcache_super = superblock_asdict(device=device)
+        sb_version = parse_sb_version(bcache_super['sb.version'])
+        return bcache_super and sb_version == 3
+
+
+def is_bcache_device(device):
+    return device.get('ID_FS_TYPE') == 'bcache'
+
+
+def probe(context=None):
+    backing = {}
+    caching = {}
+    bcache = {'backing': backing, 'caching': caching}
+    if not context:
+        return bcache
+
+    for device in context.list_devices(subsystem='block'):
+        if is_bcache_device(device):
+            devpath = device['DEVNAME']
+            sb = superblock_asdict(devpath)
+            bkey = sb['dev.uuid']
+            bconfig = {'blockdev': devpath, 'superblock': sb}
+            if is_backing(devpath):
+                backing[bkey] = bconfig
+            elif is_caching(devpath):
+                caching[bkey] = bconfig
+            else:
+                print('WARK: %s is not bcache?' % devpath)
+
+    return bcache

--- a/probert/bcache.py
+++ b/probert/bcache.py
@@ -56,7 +56,7 @@ def parse_sb_version(sb_version):
     return version
 
 
-def is_backing(device, superblock=False):
+def is_backing(device):
     """ Test if device is a bcache backing device
 
     A runtime check for an active bcache backing device is to
@@ -65,17 +65,12 @@ def is_backing(device, superblock=False):
     However if a device is not active then read the superblock
     of the device and check that sb.version == 1"""
 
-    if not superblock:
-        sys_block = '/sys/class/block/%s' % os.path.basename(device)
-        bcache_sys_attr = os.path.join(sys_block, 'bcache', 'label')
-        return os.path.exists(bcache_sys_attr)
-    else:
-        bcache_super = superblock_asdict(device=device)
-        sb_version = parse_sb_version(bcache_super['sb.version'])
-        return bcache_super and sb_version == 1
+    sys_block = '/sys/class/block/%s' % os.path.basename(device)
+    bcache_sys_attr = os.path.join(sys_block, 'bcache', 'label')
+    return os.path.exists(bcache_sys_attr)
 
 
-def is_caching(device, superblock=False):
+def is_caching(device):
     """ Test if device is a bcache caching device
 
     A runtime check for an active bcache backing device is to
@@ -84,15 +79,10 @@ def is_caching(device, superblock=False):
     However if a device is not active then read the superblock
     of the device and check that sb.version == 3"""
 
-    if not superblock:
-        sys_block = '/sys/class/block/%s' % os.path.basename(device)
-        bcache_sys_attr = os.path.join(sys_block, 'bcache',
-                                       'cache_replacement_policy')
-        return os.path.exists(bcache_sys_attr)
-    else:
-        bcache_super = superblock_asdict(device=device)
-        sb_version = parse_sb_version(bcache_super['sb.version'])
-        return bcache_super and sb_version == 3
+    sys_block = '/sys/class/block/%s' % os.path.basename(device)
+    bcache_sys_attr = os.path.join(sys_block, 'bcache',
+                                   'cache_replacement_policy')
+    return os.path.exists(bcache_sys_attr)
 
 
 def is_bcache_device(device):

--- a/probert/dmcrypt.py
+++ b/probert/dmcrypt.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import pyudev
+import subprocess
+
+log = logging.getLogger('probert.dmcrypt')
+
+
+def dmsetup_info(devname):
+    ''' returns dict of info about device mapper dev.
+
+    {'blkdevname': 'dm-0',
+     'blkdevs_used': 'sda5',
+     'name': 'sda5_crypt',
+     'subsystem': 'CRYPT',
+     'uuid': 'CRYPT-LUKS1-2b370697149743b0b2407d11f88311f1-sda5_crypt'
+    }
+    '''
+    _SEP = '='
+    fields = ('name,uuid,blkdevname,blkdevs_used,subsystem'.split(','))
+    try:
+        output = subprocess.check_output(
+            ['sudo', 'dmsetup', 'info', devname, '-C', '-o',
+             ','.join(fields), '--noheading', '--separator', _SEP])
+    except subprocess.CalledProcessError as e:
+        log.error('Failed to probe dmsetup info:', e)
+        return None
+    values = output.decode('utf-8').strip().split(_SEP)
+    info = dict(zip(fields, values))
+    return info
+
+
+def probe(context=None, report=False):
+    """ Probing for dm_crypt devices requires running dmsetup info commands
+        to collect how a particular dm-X device is composed.
+    """
+    # ignore supplied context, we need to read udev after scan/vgchange
+    context = pyudev.Context()
+
+    crypt_devices = {}
+
+    # look for block devices with DM_UUID and CRYPT; these are crypt devices
+    for device in context.list_devices(subsystem='block'):
+        if 'DM_UUID' in device and device['DM_UUID'].startswith('CRYPT'):
+            devname = device['DEVNAME']
+            dm_info = dmsetup_info(devname)
+            crypt_devices[dm_info['name']] = dm_info
+
+    return crypt_devices

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -14,27 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 import pyudev
 
 log = logging.getLogger('probert.filesystems')
-
-
-def get_supported_filesystems():
-    """ Return a list of filesystems that the kernel currently supports
-        as read from /proc/filesystems.
-
-        Raises RuntimeError if /proc/filesystems does not exist.
-    """
-    proc_fs = "/proc/filesystems"
-    if not os.path.exists(proc_fs):
-        raise RuntimeError("Unable to read 'filesystems' from %s" % proc_fs)
-
-    with open(proc_fs, 'r') as fh:
-        proc_fs_contents = fh.read()
-
-    return [l.split('\t')[1].strip()
-            for l in proc_fs_contents.splitlines()]
 
 
 def get_device_filesystem(device):
@@ -44,12 +26,8 @@ def get_device_filesystem(device):
 
 
 def probe(context=None):
-    """ Capture detected filesystems found on discovered block devices.
-        Filter the detected values via the host kernel's supported file
-        systems.
-    """
+    """ Capture detected filesystems found on discovered block devices.  """
     filesystems = {}
-    supported_fs = get_supported_filesystems()
     if not context:
         context = pyudev.Context()
 
@@ -58,7 +36,7 @@ def probe(context=None):
         # these won't ever be used in recreating storage on target systems.
         if device['MAJOR'] not in ["1", "7"]:
             fs_info = get_device_filesystem(device)
-            if fs_info and fs_info['TYPE'] in supported_fs:
+            if fs_info:
                 filesystems[device['DEVNAME']] = fs_info
 
     return filesystems

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -54,6 +54,8 @@ def probe(context=None):
         context = pyudev.Context()
 
     for device in context.list_devices(subsystem='block'):
+        # Ignore block major=1 (ramdisk) and major=7 (loopback)
+        # these won't ever be used in recreating storage on target systems.
         if device['MAJOR'] not in ["1", "7"]:
             fs_info = get_device_filesystem(device)
             if fs_info and fs_info['TYPE'] in supported_fs:

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -14,9 +14,27 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 import pyudev
 
 log = logging.getLogger('probert.filesystems')
+
+
+def get_supported_filesystems():
+    """ Return a list of filesystems that the kernel currently supports
+        as read from /proc/filesystems.
+
+        Raises RuntimeError if /proc/filesystems does not exist.
+    """
+    proc_fs = "/proc/filesystems"
+    if not os.path.exists(proc_fs):
+        raise RuntimeError("Unable to read 'filesystems' from %s" % proc_fs)
+
+    with open(proc_fs, 'r') as fh:
+        proc_fs_contents = fh.read()
+
+    return [l.split('\t')[1].strip()
+            for l in proc_fs_contents.splitlines()]
 
 
 def get_device_filesystem(device):
@@ -27,11 +45,14 @@ def get_device_filesystem(device):
 
 def probe(context=None):
     filesystems = {}
+    supported_fs = get_supported_filesystems()
     if not context:
         context = pyudev.Context()
 
     for device in context.list_devices(subsystem='block'):
         if device['MAJOR'] not in ["1", "7"]:
-            filesystems[device['DEVNAME']] = get_device_filesystem(device)
+            fs_info = get_device_filesystem(device)
+            if fs_info and fs_info['TYPE'] in supported_fs:
+                filesystems[device['DEVNAME']] = fs_info
 
     return filesystems

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -44,6 +44,10 @@ def get_device_filesystem(device):
 
 
 def probe(context=None):
+    """ Capture detected filesystems found on discovered block devices.
+        Filter the detected values via the host kernel's supported file
+        systems.
+    """
     filesystems = {}
     supported_fs = get_supported_filesystems()
     if not context:

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -1,0 +1,146 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import json
+import pyudev
+import subprocess
+
+from probert.storage import read_sys_block_size
+
+log = logging.getLogger('probert.lvm')
+
+
+class LvInfo():
+    def __init__(self, lvname, vgname, lvsize):
+        self.type = 'lvm_partition'
+        self.name = lvname
+        self.vgname = vgname
+        self.size = lvsize
+        self.fullname = "%s/%s" % (self.name, self.vgname)
+        self.id = 'lvmpart-%s' % self.name
+
+    def as_config(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'size': self.size,
+            'type': self.type,
+            'volgroup': 'lvm_volgroup-%s' % self.volgroup
+        }
+
+
+class VgInfo():
+    def __init__(self, name, devices):
+        self.type = 'lvm_volgroup'
+        self.name = name
+        self.devices = devices
+        self.id = 'lvmvol-%s' % (self.name)
+
+    def as_config(self):
+        return {
+            'id': self.id,
+            'type': self.type,
+            'name': self.name,
+            'devices': self.devices,
+        }
+
+
+class PvInfo():
+    def __init__(self, name, devpath):
+        self.type = 'lvm_physdev'
+        self.name = name
+        self.devpath = devpath
+        self.id = 'lvmphysdev-%s' % self.name
+
+    def as_config(self):
+        return {
+            'id': self.id,
+            'type': self.type,
+            'name': self.name,
+            'devpath': self.devpath
+        }
+
+
+def probe_lvm_report():
+    try:
+        output, _err = subprocess.check_output(['lvm', 'fullreport',
+                                                '--nosufix', '--units', 'B',
+                                                '--reportformat', 'json'])
+    except subprocess.CalledProcessError as e:
+        log.error('Failed to probe LVM devices on system:', e)
+        return None
+
+    try:
+        lvm_report = json.loads(output)
+    except json.decoder.JSONDecodeError as e:
+        log.error('Failed to load LVM json report:', e)
+        return None
+
+    return lvm_report
+
+
+def dmsetup_info(devname):
+    ''' returns dict of info about device mapper dev.
+
+    {'blkdevname': 'dm-0',
+     'blkdevs_used': 'sdbr,sdbq,sdbp',
+     'lv_name': 'lv_srv',
+     'subsystem': 'LVM',
+     'uuid': 'LVM-lyrZxQgOcgVSlj81LvyUnvq4DW3uLLrfJLI5ieYZR9a2fSOGBK03KM78',
+     'vg_name': 'storage_vg_242x'}
+    '''
+    _SEP = '='
+    fields = (
+        'subsystem,vg_name,lv_name,blkdevname,uuid,blkdevs_used'.split(','))
+    try:
+        output = subprocess.check_output(
+            ['sudo', 'dmsetup', 'info', devname, '-C', '-o', fields,
+             '--noheading', '--separator', _SEP])
+    except subprocess.CalledProcessError as e:
+        log.error('Failed to probe dmsetup info:', e)
+        return None
+    values = output.decode('utf-8').strip().split(_SEP)
+    info = dict(zip(fields, values))
+    return info
+
+
+class LVM():
+    def __init__(self, results={}):
+        self.results = results
+        self.context = pyudev.Context()
+
+    def probe(self):
+        lvols = []
+        vgroups = []
+        pvols = []
+        report = probe_lvm_report()
+        for device in self.context.list_devices(subsystem='block'):
+            if 'DM_UUID' in device and device['DM_UUID'].startswith('LVM'):
+                # dm_info = dmsetup_info(device['DEVNAME'])
+                new_lv = {
+                    'lv_full_name': '%s/%s' % (device['DM_VG_NAME'],
+                                               device['DM_LV_NAME']),
+                    'lv_size': read_sys_block_size(device['DEVNAME']),
+                }
+                lvols.append(new_lv)
+
+        storage = {
+            'lvm': {
+                'lvs': lvols, 'vgs': vgroups, 'pvs': pvols,
+                'report': report,
+            }
+        }
+        self.results = storage

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -115,7 +115,6 @@ def _lvm_report(cmd, report_key):
     def _flatten_list(data):
         return [y for x in data for y in x]
 
-
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.DEVNULL)
@@ -131,15 +130,19 @@ def _lvm_report(cmd, report_key):
         return None
 
     return _flatten_list([report.get(report_key)
-            for report in reports.get('report', []) if report_key in report])
+                          for report in reports.get('report', [])
+                          if report_key in report])
 
 
 def probe_pvs_report():
     return _lvm_report(['pvs', '--reportformat=json'], 'pv')
 
+
 def probe_vgs_report():
-    report_cmd = ['vgs', '--reportformat=json', '--units=B', '-o', 'vg_name,pv_name,pv_uuid,vg_size']
+    report_cmd = ['vgs', '--reportformat=json', '--units=B',
+                  '-o', 'vg_name,pv_name,pv_uuid,vg_size']
     return _lvm_report(report_cmd, 'vg')
+
 
 def probe_lvs_report():
     return _lvm_report('lvs', 'lv')
@@ -207,10 +210,11 @@ def activate_volgroups():
 
 def extract_lvm_partition(probe_data):
     lv_id = "%s/%s" % (probe_data['DM_VG_NAME'], probe_data['DM_LV_NAME'])
-    return (lv_id, {'fullname': lv_id,
-                    'name': probe_data['DM_LV_NAME'],
-                    'volgroup': probe_data['DM_VG_NAME'],
-                    'size': "%sB" % read_sys_block_size(probe_data['DEVNAME'])})
+    return (
+        lv_id, {'fullname': lv_id,
+                'name': probe_data['DM_LV_NAME'],
+                'volgroup': probe_data['DM_VG_NAME'],
+                'size': "%sB" % read_sys_block_size(probe_data['DEVNAME'])})
 
 
 def extract_lvm_volgroup(vg_name, report_data):
@@ -283,7 +287,6 @@ def probe(context=None, report=False):
 
             if vg_id not in pvols:
                 pvols[vg_id] = new_vg['devices']
-
 
     lvm = {}
     if lvols:

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -150,13 +150,26 @@ def extract_lvm_partition(probe_data):
                 'size': "%sB" % read_sys_block_size(probe_data['DEVNAME'])})
 
 
-def extract_lvm_volgroup(probe_data):
-    vg_id = probe_data['vg_name']
-    return (vg_id, {'name': vg_id,
-                    'devices':
-                        ['/dev/%s' % d
-                         for d in probe_data['blkdevs_used'].split(',')]})
+def extract_lvm_volgroup(vg_name, report_data):
+    """
+    [
+        {"vg_name":"vg0", "pv_name":"/dev/md0",
+         "pv_uuid":"p3oDow-dRHp-L8jq-t6gQ-67tv-B8B6-JWLKZP",
+         "vg_size":"21449670656B"},
+        {"vg_name":"vg0", "pv_name":"/dev/md1",
+         "pv_uuid":"pRR5Zn-c4a9-teVZ-TFaU-yDxf-FSDo-cORcEq",
+         "vg_size":"21449670656B"}
+    ]
+    """
+    devices = set()
+    for report in report_data:
+        if report['vg_name'] == vg_name:
+            size = report['vg_size']
+            devices.add(report.get('pv_name'))
 
+    return (vg_name, {'name': vg_name,
+                      'devices': list(devices),
+                      'size': size})
 
 def probe(context=None, report=False):
     """ Probing for LVM devices requires initiating a kernel level scan

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -24,26 +24,6 @@ from probert.utils import read_sys_block_size
 log = logging.getLogger('probert.lvm')
 
 
-def probe_lvm_report():
-    try:
-        cmd = ['lvm', 'fullreport', '--nosuffix', '--units', 'B',
-               '--reportformat', 'json']
-        result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.DEVNULL)
-        output = result.stdout.decode('utf-8')
-    except subprocess.CalledProcessError as e:
-        log.error('Failed to probe LVM devices on system:', e)
-        return None
-
-    try:
-        lvm_report = json.loads(output)
-    except json.decoder.JSONDecodeError as e:
-        log.error('Failed to load LVM json report:', e)
-        return None
-
-    return lvm_report
-
-
 def _lvm_report(cmd, report_key):
     """ [pvs --reportformat=json -o foo,bar] report_key='pv'
      {
@@ -214,7 +194,6 @@ def probe(context=None, report=False):
     lvols = {}
     vgroups = {}
     pvols = {}
-    report = probe_lvm_report() if report else {}
     vg_report = probe_vgs_report()
 
     for device in context.list_devices(subsystem='block'):
@@ -244,7 +223,5 @@ def probe(context=None, report=False):
         lvm.update({'physical_volumes': pvols})
     if vgroups:
         lvm.update({'volume_groups': vgroups})
-    if report:
-        lvm.update({'report': report})
 
     return lvm

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -161,11 +161,29 @@ def extract_lvm_volgroup(vg_name, report_data):
          "vg_size":"21449670656B"}
     ]
     """
+    def _int(size_val):
+        if size_val and size_val.endswith('B'):
+            return int(size_val[:-1])
+        return 0
+
     devices = set()
+    size = None
     for report in report_data:
         if report['vg_name'] == vg_name:
-            size = report['vg_size']
+            vg_size = report['vg_size']
+            # set size to the largest size we find
+            if vg_size:
+                # unset, take current value
+                if not size:
+                    size = vg_size
+                # on set but mismatched values, keep the larger
+                elif size != vg_size:
+                    if _int(vg_size) > _int(size):
+                        size = vg_size
             devices.add(report.get('pv_name'))
+
+    if size is None:
+        size = '0B'
 
     return (vg_name, {'name': vg_name,
                       'devices': list(devices),

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -123,6 +123,10 @@ def _lvm_report(cmd, report_key):
         log.error('Failed to probe LVM devices on system:', e)
         return None
 
+    if not output:
+        return
+
+    reports = {}
     try:
         reports = json.loads(output)
     except json.decoder.JSONDecodeError as e:

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -179,6 +179,31 @@ def extract_lvm_volgroup(probe_data):
 
 
 def probe(context=None, report=False):
+    """ Probing for LVM devices requires initiating a kernel level scan
+        of block devices to look for physical volumes, volume groups and
+        logical volumes.  Once detected, the prober will activate any
+        volume groups detected.
+
+        The prober will refresh the udev context which brings in addition
+        information relating to LVM devices.
+
+        This prober relies on udev detecting devices via the 'DM_UUID'
+        field and for each of such devices, the prober records the
+        logical volume.
+
+        For each logical volume, the prober determines the hosting
+        volume_group and records detailed information about the group
+        including members.  The process is repeated to determine the
+        underlying physical volumes that are used to construct a
+        volume group.
+
+        Care is taken to handle scenarios where physical volumes are
+        not yet allocated to a volume group (such as a linear VG).
+
+        On newer systems (Disco+) the lvm2 software stack provides
+        a rich reporting data dump in JSON format.  On systems with
+        older LVM2 stacks, the LVM probe may be incomplete.
+    """
     # scan and activate lvm vgs/lvs
     lvm_scan()
     activate_volgroups()

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -81,31 +81,6 @@ def probe_lvs_report():
     return _lvm_report('lvs', 'lv')
 
 
-def dmsetup_info(devname):
-    ''' returns dict of info about device mapper dev.
-
-    {'blkdevname': 'dm-0',
-     'blkdevs_used': 'sdbr,sdbq,sdbp',
-     'lv_name': 'lv_srv',
-     'subsystem': 'LVM',
-     'uuid': 'LVM-lyrZxQgOcgVSlj81LvyUnvq4DW3uLLrfJLI5ieYZR9a2fSOGBK03KM78',
-     'vg_name': 'storage_vg_242x'}
-    '''
-    _SEP = '='
-    fields = (
-        'subsystem,vg_name,lv_name,blkdevname,uuid,blkdevs_used'.split(','))
-    try:
-        output = subprocess.check_output(
-            ['sudo', 'dmsetup', 'info', devname, '-C', '-o',
-             ','.join(fields), '--noheading', '--separator', _SEP])
-    except subprocess.CalledProcessError as e:
-        log.error('Failed to probe dmsetup info:', e)
-        return None
-    values = output.decode('utf-8').strip().split(_SEP)
-    info = dict(zip(fields, values))
-    return info
-
-
 def lvmetad_running():
     return os.path.exists(os.environ.get('LVM_LVMETAD_PIDFILE',
                                          '/run/lvmetad.pid'))

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -171,6 +171,7 @@ def extract_lvm_volgroup(vg_name, report_data):
                       'devices': list(devices),
                       'size': size})
 
+
 def probe(context=None, report=False):
     """ Probing for LVM devices requires initiating a kernel level scan
         of block devices to look for physical volumes, volume groups and

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -24,57 +24,6 @@ from probert.utils import read_sys_block_size
 log = logging.getLogger('probert.lvm')
 
 
-class LvInfo():
-    def __init__(self, lvname, vgname, lvsize):
-        self.type = 'lvm_partition'
-        self.name = lvname
-        self.vgname = vgname
-        self.size = lvsize
-        self.fullname = "%s/%s" % (self.name, self.vgname)
-        self.id = 'lvmpart-%s' % self.name
-
-    def as_config(self):
-        return {
-            'id': self.id,
-            'name': self.name,
-            'size': self.size,
-            'type': self.type,
-            'volgroup': 'lvm_volgroup-%s' % self.volgroup
-        }
-
-
-class VgInfo():
-    def __init__(self, name, devices):
-        self.type = 'lvm_volgroup'
-        self.name = name
-        self.devices = devices
-        self.id = 'lvmvol-%s' % (self.name)
-
-    def as_config(self):
-        return {
-            'id': self.id,
-            'type': self.type,
-            'name': self.name,
-            'devices': self.devices,
-        }
-
-
-class PvInfo():
-    def __init__(self, name, devpath):
-        self.type = 'lvm_physdev'
-        self.name = name
-        self.devpath = devpath
-        self.id = 'lvmphysdev-%s' % self.name
-
-    def as_config(self):
-        return {
-            'id': self.id,
-            'type': self.type,
-            'name': self.name,
-            'devpath': self.devpath
-        }
-
-
 def probe_lvm_report():
     try:
         cmd = ['lvm', 'fullreport', '--nosuffix', '--units', 'B',
@@ -227,21 +176,6 @@ def extract_lvm_volgroup(probe_data):
                     'devices':
                         ['/dev/%s' % d
                          for d in probe_data['blkdevs_used'].split(',')]})
-
-
-def as_config(lv_type, lvmconf):
-    if lv_type == 'vgs':
-        return {'id': 'lvmvol-%s' % lvmconf.get('name'),
-                'type': 'lvm_volgroup',
-                'name': lvmconf.get('name'),
-                'devices': lvmconf.get('devices')}
-    if lv_type == 'lvs':
-        return {'id': 'lvmpart-%s' % lvmconf.get('name'),
-                'type': 'lvm_partition',
-                'name': lvmconf.get('name'),
-                'volgroup': 'lvmvol-%s' % lvmconf.get('volgroup'),
-                'size': str(lvmconf.get('size'))}
-    return None
 
 
 def probe(context=None, report=False):

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -217,26 +217,12 @@ def extract_lvm_partition(probe_data):
                 'size': "%sB" % read_sys_block_size(probe_data['DEVNAME'])})
 
 
-def extract_lvm_volgroup(vg_name, report_data):
-    """
-    [
-        {"vg_name":"vg0", "pv_name":"/dev/md0",
-         "pv_uuid":"p3oDow-dRHp-L8jq-t6gQ-67tv-B8B6-JWLKZP",
-         "vg_size":"21449670656B"},
-        {"vg_name":"vg0", "pv_name":"/dev/md1",
-         "pv_uuid":"pRR5Zn-c4a9-teVZ-TFaU-yDxf-FSDo-cORcEq",
-         "vg_size":"21449670656B"}
-    ]
-    """
-    devices = set()
-    for report in report_data:
-        if report['vg_name'] == vg_name:
-            size = report['vg_size']
-            devices.add(report.get('pv_name'))
-
-    return (vg_name, {'name': vg_name,
-                      'devices': list(devices),
-                      'size': size})
+def extract_lvm_volgroup(probe_data):
+    vg_id = probe_data['vg_name']
+    return (vg_id, {'name': vg_id,
+                    'devices':
+                        ['/dev/%s' % d
+                         for d in probe_data['blkdevs_used'].split(',')]})
 
 
 def as_config(lv_type, lvmconf):

--- a/probert/mount.py
+++ b/probert/mount.py
@@ -13,92 +13,32 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import namedtuple
+import json
 import logging
-import os
-import stat
-import pyudev
+import subprocess
 
-log = logging.getLogger('probert.filesystems')
-MountEntry = namedtuple("MountEntry", ('device', 'realpath', 'mountpoint',
-                                       'fstype', 'options', 'freq', 'passno'))
-MountEntry.__new__.__defaults__ = (None, None, None, None, '', '0', '0')
+log = logging.getLogger('probert.mount')
 
+def findmnt(data=None):
+    if not data:
+        cmd = ['findmnt', '--bytes', '--json']
+        try:
+            result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                    stderr=subprocess.DEVNULL)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return {}
 
-def get_supported_filesystems():
-    """ Return a list of filesystems that the kernel currently supports
-        as read from /proc/filesystems.
+        data = result.stdout.decode('utf-8')
 
-        Raises RuntimeError if /proc/filesystems does not exist.
-    """
-    proc_fs = "/proc/filesystems"
-    if not os.path.exists(proc_fs):
-        raise RuntimeError("Unable to read 'filesystems' from %s" % proc_fs)
+    try:
+        mounts = json.loads(data)
+    except json.decoder.JSONDecodeError as e:
+        log.error('Failed to load findmnt json output:', e)
+        return None
 
-    with open(proc_fs, 'r') as fh:
-        proc_fs_contents = fh.read()
-
-    return [l.split('\t')[1].strip()
-            for l in proc_fs_contents.splitlines()]
-
-
-def read_proc_mounts():
-    with open("/proc/mounts", "r") as fp:
-        return fp.read()
-
-
-def get_block_mounts(proc_mounts=None):
-    # return mount entry if device is in /proc/mounts
-
-    def is_blockdev(path):
-        return os.path.exists(path) and stat.S_ISBLK(os.stat(path).st_mode)
-
-    if not proc_mounts:
-        proc_mounts = read_proc_mounts()
-
-    block_mounts = {}
-    for line in proc_mounts.splitlines():
-        dev, mp, fs, opts, freq, passno = line.split()
-        # /proc/mounts device entry may be a symlink, resolve it
-        realpath = os.path.realpath(dev)
-        if not is_blockdev(realpath):
-            continue
-
-        entry = MountEntry(dev, realpath, mp, fs, opts, freq, passno)
-        if entry.realpath not in block_mounts:
-            block_mounts[entry.realpath] = [entry]
-        else:
-            block_mounts[entry.realpath].append(entry)
-
-    return block_mounts
-
-
-def mountentry_asdict(mount):
-    return {'mountpoint': mount.mountpoint,
-            'fstype': mount.fstype,
-            'options': mount.options,
-            'realpath': mount.realpath,
-            'device': mount.device}
+    return mounts
 
 
 def probe(context=None):
-    supported_fs = get_supported_filesystems()
-    if not context:
-        context = pyudev.Context()
-
-    blockdev_mounts = get_block_mounts()
-    mounts = {}
-    for device in context.list_devices(subsystem='block'):
-        if device['MAJOR'] not in ["1", "7"]:
-            devname = device['DEVNAME']
-            if devname in blockdev_mounts:
-                for mount in blockdev_mounts[devname]:
-                    if mount.fstype not in supported_fs:
-                        continue
-
-                    if mount.device in mounts:
-                        mounts[mount.device].append(mountentry_asdict(mount))
-                    else:
-                        mounts[mount.device] = [mountentry_asdict(mount)]
-
-    return mounts
+    mounts  = findmnt()
+    return mounts.get('filesystems', {})

--- a/probert/mount.py
+++ b/probert/mount.py
@@ -19,6 +19,7 @@ import subprocess
 
 log = logging.getLogger('probert.mount')
 
+
 def findmnt(data=None):
     if not data:
         cmd = ['findmnt', '--bytes', '--json']
@@ -30,15 +31,14 @@ def findmnt(data=None):
 
         data = result.stdout.decode('utf-8')
 
+    mounts = {}
     try:
         mounts = json.loads(data)
     except json.decoder.JSONDecodeError as e:
         log.error('Failed to load findmnt json output:', e)
-        return None
 
     return mounts
 
 
 def probe(context=None):
-    mounts  = findmnt()
-    return mounts.get('filesystems', {})
+    return findmnt().get('filesystems', {})

--- a/probert/mount.py
+++ b/probert/mount.py
@@ -41,4 +41,8 @@ def findmnt(data=None):
 
 
 def probe(context=None):
+    """The probert uses the util-linux 'findmnt' command which
+       dumps a JSON tree of detailed information about _all_
+       mounts in the current linux system.
+    """
     return findmnt().get('filesystems', {})

--- a/probert/mount.py
+++ b/probert/mount.py
@@ -1,0 +1,104 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import namedtuple
+import logging
+import os
+import stat
+import pyudev
+
+log = logging.getLogger('probert.filesystems')
+MountEntry = namedtuple("MountEntry", ('device', 'realpath', 'mountpoint',
+                                       'fstype', 'options', 'freq', 'passno'))
+MountEntry.__new__.__defaults__ = (None, None, None, None, '', '0', '0')
+
+
+def get_supported_filesystems():
+    """ Return a list of filesystems that the kernel currently supports
+        as read from /proc/filesystems.
+
+        Raises RuntimeError if /proc/filesystems does not exist.
+    """
+    proc_fs = "/proc/filesystems"
+    if not os.path.exists(proc_fs):
+        raise RuntimeError("Unable to read 'filesystems' from %s" % proc_fs)
+
+    with open(proc_fs, 'r') as fh:
+        proc_fs_contents = fh.read()
+
+    return [l.split('\t')[1].strip()
+            for l in proc_fs_contents.splitlines()]
+
+
+def read_proc_mounts():
+    with open("/proc/mounts", "r") as fp:
+        return fp.read()
+
+
+def get_block_mounts(proc_mounts=None):
+    # return mount entry if device is in /proc/mounts
+
+    def is_blockdev(path):
+        return os.path.exists(path) and stat.S_ISBLK(os.stat(path).st_mode)
+
+    if not proc_mounts:
+        proc_mounts = read_proc_mounts()
+
+    block_mounts = {}
+    for line in proc_mounts.splitlines():
+        dev, mp, fs, opts, freq, passno = line.split()
+        # /proc/mounts device entry may be a symlink, resolve it
+        realpath = os.path.realpath(dev)
+        if not is_blockdev(realpath):
+            continue
+
+        entry = MountEntry(dev, realpath, mp, fs, opts, freq, passno)
+        if entry.realpath not in block_mounts:
+            block_mounts[entry.realpath] = [entry]
+        else:
+            block_mounts[entry.realpath].append(entry)
+
+    return block_mounts
+
+
+def mountentry_asdict(mount):
+    return {'mountpoint': mount.mountpoint,
+            'fstype': mount.fstype,
+            'options': mount.options,
+            'realpath': mount.realpath,
+            'device': mount.device}
+
+
+def probe(context=None):
+    supported_fs = get_supported_filesystems()
+    if not context:
+        context = pyudev.Context()
+
+    blockdev_mounts = get_block_mounts()
+    mounts = {}
+    for device in context.list_devices(subsystem='block'):
+        if device['MAJOR'] not in ["1", "7"]:
+            devname = device['DEVNAME']
+            if devname in blockdev_mounts:
+                for mount in blockdev_mounts[devname]:
+                    if mount.fstype not in supported_fs:
+                        continue
+
+                    if mount.device in mounts:
+                        mounts[mount.device].append(mountentry_asdict(mount))
+                    else:
+                        mounts[mount.device] = [mountentry_asdict(mount)]
+
+    return mounts

--- a/probert/multipath.py
+++ b/probert/multipath.py
@@ -1,0 +1,70 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import namedtuple
+import logging
+import subprocess
+
+MPath = namedtuple("MPath", ('device', 'serial', 'multipath', 'host_wwnn',
+                             'target_wwnn', 'host_wwpn', 'host_wwpn',
+                             'host_adapter'))
+MMap = namedtuple("MMap", ('multipath', 'sysfs', 'paths'))
+log = logging.getLogger('probert.multipath')
+
+
+def multipath_show_paths():
+    path_format = "%d %z %m %N %n %R %r %a".split()
+    cmd = ['multipathd', 'show', 'paths', 'raw', 'format'] + path_format
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {}
+
+    data = result.stdout.decode('utf-8')
+    paths = []
+    for line in data.splitlines():
+        paths.append(MPath(*line.split()))
+
+    return paths
+
+
+def multipath_show_maps():
+    maps_format = "%w %d %N"
+    cmd = ['multipathd', 'show', 'maps', 'raw', 'format'] + maps_format
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {}
+
+    data = result.stdout.decode('utf-8')
+    maps = []
+    for line in data.splitlines():
+        maps.append(MMap(*line.split()))
+
+    return maps
+
+
+def probe(context=None):
+    results = {}
+    maps = multipath_show_maps()
+    if maps:
+        results.update({'maps': maps})
+    paths = multipath_show_paths()
+    if paths:
+        results.update({'paths': maps})
+
+    return results

--- a/probert/multipath.py
+++ b/probert/multipath.py
@@ -18,15 +18,15 @@ import logging
 import subprocess
 
 MPath = namedtuple("MPath", ('device', 'serial', 'multipath', 'host_wwnn',
-                             'target_wwnn', 'host_wwpn', 'host_wwpn',
+                             'target_wwnn', 'host_wwpn', 'target_wwpn',
                              'host_adapter'))
 MMap = namedtuple("MMap", ('multipath', 'sysfs', 'paths'))
 log = logging.getLogger('probert.multipath')
 
 
 def multipath_show_paths():
-    path_format = "%d %z %m %N %n %R %r %a".split()
-    cmd = ['multipathd', 'show', 'paths', 'raw', 'format'] + path_format
+    path_format = "%d %z %m %N %n %R %r %a"
+    cmd = ['multipathd', 'show', 'paths', 'raw', 'format', path_format]
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.DEVNULL)
@@ -36,14 +36,14 @@ def multipath_show_paths():
     data = result.stdout.decode('utf-8')
     paths = []
     for line in data.splitlines():
-        paths.append(MPath(*line.split()))
+        paths.append(MPath(*line.split())._asdict())
 
     return paths
 
 
 def multipath_show_maps():
     maps_format = "%w %d %N"
-    cmd = ['multipathd', 'show', 'maps', 'raw', 'format'] + maps_format
+    cmd = ['multipathd', 'show', 'maps', 'raw', 'format', maps_format]
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.DEVNULL)
@@ -53,7 +53,7 @@ def multipath_show_maps():
     data = result.stdout.decode('utf-8')
     maps = []
     for line in data.splitlines():
-        maps.append(MMap(*line.split()))
+        maps.append(MMap(*line.split())._asdict())
 
     return maps
 
@@ -65,6 +65,6 @@ def probe(context=None):
         results.update({'maps': maps})
     paths = multipath_show_paths()
     if paths:
-        results.update({'paths': maps})
+        results.update({'paths': paths})
 
     return results

--- a/probert/multipath.py
+++ b/probert/multipath.py
@@ -59,6 +59,15 @@ def multipath_show_maps():
 
 
 def probe(context=None):
+    """Query the multipath daemon for multipath maps and paths.
+
+       This data is useful for determining whether a specific block
+       device is part of a multipath and if so which device-mapper (dm)
+       blockdevice should be used.
+
+       This probe requires multipath module to be loaded and the multipath
+       daemon to be running.
+    """
     results = {}
     maps = multipath_show_maps()
     if maps:

--- a/probert/network.py
+++ b/probert/network.py
@@ -824,6 +824,7 @@ class NetworkProber:
         return {'version': 2, 'ethernets': {}, 'wifis': {}, 'bonds': {},
                 'bridges': {}, 'vlans': {}}
 
+
 if __name__ == '__main__':
     import pprint
     import select

--- a/probert/network.py
+++ b/probert/network.py
@@ -820,10 +820,6 @@ class NetworkProber:
             results['routes'].append(route_data)
         return results
 
-    def export(self):
-        return {'version': 2, 'ethernets': {}, 'wifis': {}, 'bonds': {},
-                'bridges': {}, 'vlans': {}}
-
 
 if __name__ == '__main__':
     import pprint

--- a/probert/network.py
+++ b/probert/network.py
@@ -820,6 +820,9 @@ class NetworkProber:
             results['routes'].append(route_data)
         return results
 
+    def export(self):
+        return {'version': 2, 'ethernets': {}, 'wifis': {}, 'bonds': {},
+                'bridges': {}, 'vlans': {}}
 
 if __name__ == '__main__':
     import pprint

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
 class Prober():
     def __init__(self):
         self._results = {}

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from probert.network import NetworkProber
-from probert.storage import Storage
 
 
 class Prober():
@@ -27,10 +25,12 @@ class Prober():
         self.probe_network()
 
     def probe_storage(self):
+        from probert.storage import Storage
         self._storage = Storage()
         self._results['storage'] = self._storage.probe()
 
     def probe_network(self):
+        from probert.network import NetworkProber
         self._network = NetworkProber()
         self._results['network'] = self._network.probe()
 

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -17,7 +17,6 @@
 class Prober():
     def __init__(self):
         self._results = {}
-        self._config = {}
 
     def probe_all(self):
         self.probe_storage()

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from probert.storage import Storage
+from probert.lvm import LVM
 from probert.network import NetworkProber
+from probert.storage import Storage
 
 
 class Prober():
@@ -25,11 +26,17 @@ class Prober():
     def probe_all(self):
         self.probe_storage()
         self.probe_network()
+        self.probe_lvm()
 
     def probe_storage(self):
         self._storage = Storage()
         self._results['storage'] = self._storage.probe()
         self._config['storage'] = self._storage.export()
+
+    def probe_lvm(self):
+        self._lvm = LVM()
+        self._results['lvm'] = self._lvm.probe(report=True)
+        self._config['lvm'] = self._lvm.export()
 
     def probe_network(self):
         self._network = NetworkProber()

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -20,16 +20,24 @@ from probert.network import NetworkProber
 class Prober():
     def __init__(self):
         self._results = {}
+        self._config = {}
 
     def probe_all(self):
         self.probe_storage()
         self.probe_network()
 
     def probe_storage(self):
-        self._results['storage'] = Storage().probe()
+        self._storage = Storage()
+        self._results['storage'] = self._storage.probe()
+        self._config['storage'] = self._storage.export()
 
     def probe_network(self):
-        self._results['network'] = NetworkProber().probe()
+        self._network = NetworkProber()
+        self._results['network'] = self._network.probe()
+        self._config['network'] = self._network.export()
 
     def get_results(self):
         return self._results
+
+    def export_config(self):
+        return self._config

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -15,6 +15,7 @@
 
 from probert.lvm import LVM
 from probert.network import NetworkProber
+from probert.raid import MDADM
 from probert.storage import Storage
 
 
@@ -27,6 +28,7 @@ class Prober():
         self.probe_storage()
         self.probe_network()
         self.probe_lvm()
+        self.probe_raid()
 
     def probe_storage(self):
         self._storage = Storage()
@@ -42,6 +44,11 @@ class Prober():
         self._network = NetworkProber()
         self._results['network'] = self._network.probe()
         self._config['network'] = self._network.export()
+
+    def probe_raid(self):
+        self._raid = MDADM()
+        self._results['raid'] = self._raid.probe(report=True)
+        self._config['raid'] = self._raid.export()
 
     def get_results(self):
         return self._results

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -120,13 +120,12 @@ class MDADM():
                 attrs['size'] = str(read_sys_block_size(devname))
                 raids[devname] = dict(device)
 
-        self.results = {'raid': raids}
+        self.results = raids
         return self.results
 
     def export(self):
         raids = []
-        raid_config = self.results.get('raid', {})
-        for devname, conf in raid_config.items():
+        for devname, conf in self.results.items():
             cfg = as_config(devname, conf)
             if cfg:
                 raids.append(cfg)

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -52,7 +52,7 @@ def get_mdadm_array_spares(md_device, detail):
         return data.get(role_key_to_dev(key))
 
     return [get_dev_from_key(key, detail) for key in detail.keys()
-            if keymatch(key)]
+            if keymatch(key, detail, 'spare')]
 
 
 def get_mdadm_array_members(md_device, detail):

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -123,10 +123,7 @@ def probe(context=None, report=False):
             devname = device['DEVNAME']
             attrs = udev_get_attributes(device)
             attrs['size'] = str(read_sys_block_size(devname))
-
-            raid_name = extract_mdadm_raid_name(device)
             devices, spares = get_mdadm_array_members(devname, device)
-
             cfg = dict(device)
             cfg.update({'raidlevel': device['MD_LEVEL'],
                         'devices': devices,

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -131,6 +131,6 @@ def probe(context=None, report=False):
             cfg.update({'raidlevel': device['MD_LEVEL'],
                         'devices': devices,
                         'spare_devices': spares})
-            raids[raid_name] = cfg
+            raids[devname] = cfg
 
     return raids

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -1,0 +1,110 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import pyudev
+import subprocess
+
+from probert.utils import (read_sys_block_size,
+                           read_sys_block_slaves,
+                           udev_get_attributes)
+
+log = logging.getLogger('probert.raid')
+
+SUPPORTED_RAID_TYPES = ['raid0', 'raid1', 'raid5', 'raid6', 'raid10']
+
+
+def mdadm_assemble(scan=True, ignore_errors=True):
+    cmd = ['mdadm', '--detail', '--scan', '-v']
+    try:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError as e:
+        log.error('Failed mdadm_assemble command %s: %s', cmd, e)
+
+    return
+
+
+def get_mdadm_array_members(md_device, detail):
+
+    md_devices = int(detail.get('MD_DEVICES'))
+    md_device_keys = [key for key in detail.keys()
+                      if key.startswith('MD_DEVICE_') and key.endswith('_DEV')]
+    if len(md_device_keys) != md_devices:
+        log.warning('mdadm: mismatch on expected number of array members:'
+                    ' device(%s) expected(%s) found(%s)',
+                    md_device, md_devices, len(md_device_keys))
+
+    expected_devices = sorted(['/dev/' + dev
+                               for dev in read_sys_block_slaves(md_device)])
+    found_devices = sorted([detail[key] for key in md_device_keys])
+    if found_devices != expected_devices:
+        log.warning('mdadm: mismatch on expected array members:'
+                    ' device(%s) expected(%s) != found(%s)',
+                    md_device, expected_devices, found_devices)
+
+    return found_devices
+
+
+def extract_mdadm_raid_name(conf):
+    raid_name = conf.get('MD_NAME')
+    if ':' in raid_name:
+        _, raid_name = raid_name.split(':')
+    return raid_name
+
+
+def as_config(devname, conf):
+    if conf.get('MD_LEVEL') in SUPPORTED_RAID_TYPES:
+        raid_name = extract_mdadm_raid_name(conf)
+        return {'id': 'mdadm-%s' % raid_name,
+                'type': 'raid',
+                'name': raid_name,
+                'raidlevel': conf.get('MD_LEVEL'),
+                'devices': get_mdadm_array_members(devname, conf),
+                'spare_devices': None}
+
+    return None
+
+
+class MDADM():
+    def __init__(self, results={}):
+        self.results = results
+        self.context = None
+
+    def probe(self, report=False):
+        mdadm_assemble()
+
+        # read udev afte probing
+        self.context = pyudev.Context()
+
+        raids = {}
+        for device in self.context.list_devices(subsystem='block'):
+            if 'MD_NAME' in device:
+                devname = device['DEVNAME']
+                attrs = udev_get_attributes(device)
+                attrs['size'] = str(read_sys_block_size(devname))
+                raids[devname] = dict(device)
+
+        self.results = {'raid': raids}
+        return self.results
+
+    def export(self):
+        raids = []
+        raid_config = self.results.get('raid', {})
+        for devname, conf in raid_config.items():
+            cfg = as_config(devname, conf)
+            if cfg:
+                raids.append(cfg)
+
+        return {'version': 1, 'config': raids}

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -97,21 +97,14 @@ def extract_mdadm_raid_name(conf):
     return raid_name
 
 
-def as_config(devname, conf):
-    if conf.get('MD_LEVEL') in SUPPORTED_RAID_TYPES:
-        raid_name = extract_mdadm_raid_name(conf)
-        devices, spares = get_mdadm_array_members(devname, conf)
-        return {'id': 'mdadm-%s' % raid_name,
-                'type': 'raid',
-                'name': raid_name,
-                'raidlevel': conf.get('MD_LEVEL'),
-                'devices': devices,
-                'spare_devices': spares}
-
-    return None
-
-
 def probe(context=None, report=False):
+    """Initiate an mdadm assemble to awaken existing MDADM devices.
+       For each md block device, extract required information needed
+       to describe the array for recreation or reuse as needed.
+
+       mdadm tooling provides information about the raid type,
+       the members, the size, the name, uuids, metadata version.
+    """
     mdadm_assemble()
 
     # ignore passed context, must read udev after assembling mdadm devices

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -31,6 +31,8 @@ def mdadm_assemble(scan=True, ignore_errors=True):
         subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError as e:
         log.error('Failed mdadm_assemble command %s: %s', cmd, e)
+    except FileNotFoundError as e:
+        log.error('Failed mdadm_assemble, mdadm command not found: %s', e)
 
     return
 

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -174,7 +174,6 @@ class Storage():
         cfg = {'version': 1, 'config': []}
         disks = []
         partitions = []
-        filesystems = []
         for device, info in self.results.items():
             cfg = as_config(info)
             if cfg['type'] == 'disk':

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -145,6 +145,9 @@ class Storage():
         self.results = storage
         return storage
 
+    def export(self):
+        return {'version': 1, 'config': {}}
+
 
 def read_sys_block_size(device):
     device_dir = os.path.join('/sys/class/block', os.path.basename(device))

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -128,23 +128,7 @@ class Storage():
 
     def _get_device_size(self, device, is_partition=False):
         ''' device='/dev/sda' '''
-        device_dir = os.path.join('/sys/class/block', os.path.basename(device))
-        blockdev_size = os.path.join(device_dir, 'size')
-        with open(blockdev_size) as d:
-            size = int(d.read().strip())
-
-        logsize_base = device_dir
-        if not os.path.exists(os.path.join(device_dir, 'queue')):
-            parent_dev = os.path.basename(re.split('[\d+]', device)[0])
-            logsize_base = os.path.join('/sys/class/block', parent_dev)
-
-        logical_size = os.path.join(logsize_base, 'queue',
-                                    'logical_block_size')
-        if os.path.exists(logical_size):
-            with open(logical_size) as s:
-                size *= int(s.read().strip())
-
-        return size
+        return read_sys_block_size(device)
 
     def probe(self):
         storage = {}
@@ -160,3 +144,22 @@ class Storage():
 
         self.results = storage
         return storage
+
+
+def read_sys_block_size(device):
+    device_dir = os.path.join('/sys/class/block', os.path.basename(device))
+    blockdev_size = os.path.join(device_dir, 'size')
+    with open(blockdev_size) as d:
+        size = int(d.read().strip())
+
+    logsize_base = device_dir
+    if not os.path.exists(os.path.join(device_dir, 'queue')):
+        parent_dev = os.path.basename(re.split('[\d+]', device)[0])
+        logsize_base = os.path.join('/sys/class/block', parent_dev)
+
+    logical_size = os.path.join(logsize_base, 'queue', 'logical_block_size')
+    if os.path.exists(logical_size):
+        with open(logical_size) as s:
+            size *= int(s.read().strip())
+
+    return size

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -19,7 +19,7 @@ import re
 import pyudev
 
 from probert.utils import udev_get_attributes, read_sys_block_size
-from probert import bcache, filesystem, lvm, raid, zfs
+from probert import bcache, filesystem, lvm, mount, raid, zfs
 
 log = logging.getLogger('probert.storage')
 
@@ -213,7 +213,7 @@ class Storage():
         'blockdev': blockdev_probe,
         'filesystem': filesystem.probe,
         'lvm': lvm.probe,
-        'mounts': None,
+        'mount': mount.probe,
         'raid': raid.probe,
         'zfs': zfs.probe
     }

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -14,8 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
-import re
 import pyudev
 
 from probert.utils import udev_get_attributes, read_sys_block_size

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -208,6 +208,19 @@ class Blockdev():
 
 
 class Storage():
+    """ The Storage class includes a map of storage types that
+        probert knows how to extract required information needed
+        for installation and use.  Each storage module included
+        provides a probe method which will prepare and probe the
+        environment for the specific type of storage devices.
+
+        The result of each probe is collected into a dictionary
+        which is collected in the class .results attribute.
+
+        The probe is non-destructive and read-only; however a
+        probe module may load additional modules if they are not
+        present.
+    """
     probe_map = {
         'bcache': bcache.probe,
         'blockdev': blockdev_probe,

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -19,7 +19,7 @@ import re
 import pyudev
 
 from probert.utils import udev_get_attributes, read_sys_block_size
-from probert import bcache, filesystem, lvm, mount, raid, zfs
+from probert import bcache, filesystem, lvm, mount, multipath, raid, zfs
 
 log = logging.getLogger('probert.storage')
 
@@ -214,6 +214,7 @@ class Storage():
         'filesystem': filesystem.probe,
         'lvm': lvm.probe,
         'mount': mount.probe,
+        'multipath': multipath.probe,
         'raid': raid.probe,
         'zfs': zfs.probe
     }

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -17,7 +17,8 @@ import logging
 import pyudev
 
 from probert.utils import udev_get_attributes, read_sys_block_size
-from probert import bcache, filesystem, lvm, mount, multipath, raid, zfs
+from probert import (bcache, dmcrypt, filesystem, lvm, mount, multipath,
+                     raid, zfs)
 
 log = logging.getLogger('probert.storage')
 
@@ -120,6 +121,7 @@ class Storage():
     probe_map = {
         'bcache': bcache.probe,
         'blockdev': blockdev_probe,
+        'dmcrypt': dmcrypt.probe,
         'filesystem': filesystem.probe,
         'lvm': lvm.probe,
         'mount': mount.probe,

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -223,3 +223,22 @@ def parse_etc_network_interfaces(ifaces, contents, path):
     for iface in ifaces.keys():
         if 'auto' not in ifaces[iface]:
             ifaces[iface]['auto'] = False
+
+
+def read_sys_block_size(device):
+    device_dir = os.path.join('/sys/class/block', os.path.basename(device))
+    blockdev_size = os.path.join(device_dir, 'size')
+    with open(blockdev_size) as d:
+        size = int(d.read().strip())
+
+    logsize_base = device_dir
+    if not os.path.exists(os.path.join(device_dir, 'queue')):
+        parent_dev = os.path.basename(re.split('[\d+]', device)[0])
+        logsize_base = os.path.join('/sys/class/block', parent_dev)
+
+    logical_size = os.path.join(logsize_base, 'queue', 'logical_block_size')
+    if os.path.exists(logical_size):
+        with open(logical_size) as s:
+            size *= int(s.read().strip())
+
+    return size

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -242,3 +242,8 @@ def read_sys_block_size(device):
             size *= int(s.read().strip())
 
     return size
+
+
+def read_sys_block_slaves(device):
+    device_dir = os.path.join('/sys/class/block', os.path.basename(device))
+    return os.listdir(os.path.join(device_dir, 'slaves'))

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -1,0 +1,193 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import namedtuple
+import logging
+import operator
+import re
+import subprocess
+from functools import reduce
+
+
+log = logging.getLogger('probert.zfs')
+ZfsListEntry = namedtuple('ZfsListEntry',
+                          ('name', 'used', 'avail', 'refer', 'mountpoint'))
+
+
+def parse_zdb_output(data):
+    """ Parse structured zdb output into a dictionary.
+
+    hogshead:
+        version: 5000
+        name: 'hogshead'
+        vdev_tree:
+            type: 'root'
+            id: 0
+            guid: 12392392111803944759
+            children[0]:
+                type: 'raidz'
+                ashift: 12
+                children[0]:
+                    type: 'disk'
+                    id: 0
+                    guid: 13921270083288950156
+                    path: '/dev/disk/by-id/usb-ST4000VN_000-1H4168-0:0-part1'
+                    whole_disk: 1
+                    DTL: 140
+                    create_txg: 4
+                    com.delphix:vdev_zap_leaf: 231
+                children[1]:
+                    type: 'disk'
+                    id: 1
+                    guid: 2635788368927674810
+                    path: '/dev/disk/by-id/usb-ST4000VN_000-1H4168-0:1-part1'
+                    whole_disk: 1
+                    DTL: 139
+                    create_txg: 4
+                    com.delphix:vdev_zap_leaf: 232
+    """
+
+    def get_from_dict(datadict, maplist):
+        return reduce(operator.getitem, maplist, datadict)
+
+    def set_in_dict(datadict, maplist, value):
+        get_from_dict(datadict, maplist[:-1])[maplist[-1]] = value
+
+    def parse_line_key_value(line):
+        """ use ': ' token to split line into key, value pairs
+
+        com.delphi:vdev_zap_top: 230
+                               ^^
+                                `- span() = (24, 26)
+        key = 'com.delphi:vdev_zap_top'
+        value = '230'
+        """
+        match = re.search(r': ', line)
+        if match:
+            tok_start, tok_end = match.span()
+            key, value = (line[:tok_start], line[tok_end:])
+        else:
+            key, value = line.split(':')
+
+        return (key.lstrip(), value.replace("'", ""))
+
+    # for each line in zdb output, calculate the nested level
+    # based on indentation. Add key/value pairs for each line
+    # and generate a list of keys to calcaulate where in the root
+    # dictionary to set the value.
+    root = {}
+    lvl_tok = 4
+    prev_item = []
+    for line in data.splitlines():
+        current_level = int((len(line) - len(line.lstrip(' '))) / lvl_tok)
+        prev_level = len(prev_item) - 1
+        key, value = parse_line_key_value(line)
+        # TODO: handle children[N] keyname an convert to list
+        if current_level == 0:
+            root[key] = {}
+            prev_item = [(current_level, key)]
+        else:
+            new_item_path = [item[1]
+                             for item in prev_item[0: current_level]] + [key]
+            if value:
+                set_in_dict(root, new_item_path, value)
+            else:
+                set_in_dict(root, new_item_path, {})
+                # we've dropped down a level, replace prev level key w/new key
+                if current_level == prev_level:
+                    prev_item.pop()
+                prev_item.append((current_level, key))
+
+    return root
+
+
+def zdb_asdict(data=None):
+    """ Convert output from bcache-super-show into a dictionary"""
+    if not data:
+        cmd = ['zdb']
+        try:
+            result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                    stderr=subprocess.DEVNULL)
+        except subprocess.ProcessExecutionError:
+            # zdb returns non-zero if there are no devices
+            return {}
+
+        data = result.stdout.decode('utf-8')
+
+    return parse_zdb_output(data)
+
+
+def zfs_list_filesystems(raw_output=False):
+    cmd = ['zfs', 'list', '-Hp', '-t', 'filesystem']
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL)
+    except subprocess.ProcessExecutionError:
+        return []
+
+    data = result.stdout.decode('utf-8')
+    if raw_output:
+        return data
+
+    # NAME, USED, AVAIL, REFER, MOUNTPOINT
+    zfs_entries = []
+    for line in data.splitlines():
+        (name, used, avail, refer, mpoint) = line.split('\t')
+        if mpoint == 'none':
+            mpoint = None
+        zfs_entries.append(ZfsListEntry(name, used, avail, refer, mpoint))
+
+    return zfs_entries
+
+
+def zfs_get_properties(zfs_name, raw_output=False):
+    if not zfs_name:
+        raise ValueError('Invalid zfs_name parameter: "%s"', zfs_name)
+
+    cmd = ['zfs', 'get', 'all', '-Hp', zfs_name]
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL)
+    except subprocess.ProcessExecutionError:
+        return []
+
+    data = result.stdout.decode('utf-8')
+    if raw_output:
+        return data
+
+    # NAME, PROPERTY, VALUE, SOURCE
+    zprops = {}
+    for line in data.splitlines():
+        (name, prop, value, source) = line.split('\t')
+        zprops[prop] = {'value': value, 'source': source}
+
+    return {zfs_name: {'properties': zprops}}
+
+
+def is_zfs_device(device):
+    return device.get('ID_FS_TYPE') == 'zfs_member'
+
+
+def probe(context=None):
+    zdb = zdb_asdict()
+    zpools = {}
+    for zpool, zdb_dump in zdb.items():
+        datasets = {}
+        zlf = zfs_list_filesystems()
+        for zfs_entry in zlf:
+            datasets[zfs_entry.name] = zfs_get_properties(zfs_entry.name)
+        zpools[zpool] = {'zdb': zdb_dump, 'datasets': datasets}
+
+    return {'zpools': zpools}

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -120,7 +120,7 @@ def zdb_asdict(data=None):
         try:
             result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.DEVNULL)
-        except subprocess.ProcessExecutionError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             # zdb returns non-zero if there are no devices
             return {}
 
@@ -134,7 +134,7 @@ def zfs_list_filesystems(raw_output=False):
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.DEVNULL)
-    except subprocess.ProcessExecutionError:
+    except subprocess.CalledProcessError:
         return []
 
     data = result.stdout.decode('utf-8')

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -16,6 +16,7 @@
 from collections import namedtuple
 import logging
 import operator
+import os
 import re
 import subprocess
 from functools import reduce
@@ -114,14 +115,16 @@ def parse_zdb_output(data):
 
 
 def zdb_asdict(data=None):
-    """ Convert output from bcache-super-show into a dictionary"""
+    """ Convert output from zdb into a dictionary"""
     if not data:
         cmd = ['zdb']
+        # exported, altroot, and uncached pools need -e
+        if not os.path.exists('/etc/zfs/zpool.cache'):
+            cmd.append('-e')
         try:
             result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.DEVNULL)
         except (subprocess.CalledProcessError, FileNotFoundError):
-            # zdb returns non-zero if there are no devices
             return {}
 
         data = result.stdout.decode('utf-8')

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -184,6 +184,19 @@ def is_zfs_device(device):
 
 
 def probe(context=None):
+    """The ZFS prober examines the ZFS Dubugger (zdb) output which
+    produces psuedo-json output.  This is converted to a dictionary
+    where for each zpool, we can extract the datasets and determine
+    which vdevs (linux block devices) are used to construct the the
+    zpool.
+
+    For each zpool and dataset, the prober further extracts all of
+    the pool and filesystem (dataset) properties and captures if
+    the values and whether they are local changes or defaults.
+
+    The resulting output includes the converted zdb dump and
+    a tree of datasets and their properties.
+    """
     zdb = zdb_asdict()
     zpools = {}
     for zpool, zdb_dump in zdb.items():


### PR DESCRIPTION
Add storage probing for additional devices

Probert storage can now probe:
  - bcache
  - raid (mdadm)
  - lvm
  - multipath
  - zfs
  - mounts
  - filesystems
 
The storage prober will attempt to collect information for each of these storage types
and include them in the storage json output.  The output of storage probe is different.
Previously the top-level 'storage' key included a dictionary indexed by the block device
name.  This is now moved under the key 'blockdev' and remains in the same format.
New keys have been introduced for the various probe types:

storage:
   bcache:
     backing: {}
     caching: {}
   blockdev: {}
   filesystem: {}
   lvm: {}
   mount: {}
   multipath: {}
   zfs:
      zpools: {}


   
