### PR TITLE
Modify debian/ packaging to rely on setup.py requirements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,8 @@ probert (0.0.15) UNRELEASED; urgency=medium
     - Add Build-Depends on python3-testtools for testing
     - Bump Standards-Version to 4.3.0
       - Update priority from extra to optional
+    - Remove python3-yaml from Build-Depends and Depends; it isn't actually
+      used by the package
   * d/rules:
     - Re-enable dh_auto_test
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,8 @@ probert (0.0.15) UNRELEASED; urgency=medium
       - Update priority from extra to optional
     - Remove python3-yaml from Build-Depends and Depends; it isn't actually
       used by the package
+    - Drop hard-coded Depends now that setup.py correctly expresses
+      dependencies
   * d/rules:
     - Re-enable dh_auto_test
 

--- a/debian/control
+++ b/debian/control
@@ -25,8 +25,7 @@ Vcs-Git: https://github.com/CanonicalLtd/probert.git
 
 Package: probert
 Architecture: any
-Depends: python3-pyudev,
-         ${misc:Depends},
+Depends: ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends}
 Description: Hardware probing tool

--- a/debian/control
+++ b/debian/control
@@ -17,8 +17,7 @@ Build-Depends: debhelper (>= 9),
                python3-nose,
                python3-pyudev,
                python3-setuptools,
-               python3-testtools,
-               python3-yaml
+               python3-testtools
 Standards-Version: 4.3.0
 Homepage: https://github.com/CanonicalLtd/probert
 Vcs-Browser: https://github.com/CanonicalLtd/probert
@@ -27,7 +26,6 @@ Vcs-Git: https://github.com/CanonicalLtd/probert.git
 Package: probert
 Architecture: any
 Depends: python3-pyudev,
-         python3-yaml,
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends}

--- a/probert/tests/fakes.py
+++ b/probert/tests/fakes.py
@@ -1,5 +1,4 @@
 import os
-import yaml
 
 TOP_DIR = os.path.join('/'.join(__file__.split('/')[:-3]))
 TEST_DATA = os.path.join(TOP_DIR, 'probert', 'tests', 'data')


### PR DESCRIPTION
This also drops the dependencies on python3-yaml, because it isn't actually used.

This will close #49.