### PR TITLE
lvm: return empty dict if pvs/vgs/lvs return no output

### DIFF
--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -53,7 +53,7 @@ def _lvm_report(cmd, report_key):
         return None
 
     if not output:
-        return
+        return {}
 
     reports = {}
     try:


### PR DESCRIPTION
On systems with older lvm2 tools, the requested output may not be present but the command does not return a non-zero output; keep the type consistent by returning empty dict.