### PR TITLE
zfs: remove double dataset names in dictionary

### DIFF
--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -203,7 +203,7 @@ def probe(context=None):
         datasets = {}
         zlf = zfs_list_filesystems()
         for zfs_entry in zlf:
-            datasets[zfs_entry.name] = zfs_get_properties(zfs_entry.name)
+            datasets.update(zfs_get_properties(zfs_entry.name))
         zpools[zpool] = {'zdb': zdb_dump, 'datasets': datasets}
 
     return {'zpools': zpools}


### PR DESCRIPTION
zfs_get_properties returns a dictionary, and the
caller added the result to an entry in the dictionary
resulting in nested keys like:

 datasets:
   rpool:
     rpool:
       {properties}

This patch removes the double key.