### PR TITLE
testing: enable tox, travis, flake8, and pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+dist: xenial
+install:
+  - apt-get install tox
+script:
+  - make test
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8-dev
+  allow_failures:
+    - python: 3.8-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 dist: xenial
 install:
-  - apt-get install tox
+  - sudo apt-get update --quiet --quiet
+  - sudo apt-get install tox --yes
 script:
   - make test
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 NAME=probert
 VERSION=$(shell PYTHONPATH=$(shell pwd) python -c "import probert; print probert.__version__")
-.PHONY: all version tarball $(NAME)_$(VERSION).orig.tar.gz
+.PHONY: all version tarball test $(NAME)_$(VERSION).orig.tar.gz
 
 all: run
 
@@ -36,11 +36,5 @@ clean:
 run:
 	(PYTHONPATH=$(shell pwd) bin/probert --all)
 
-lint:
-	echo "Running flake8 lint tests..."
-	flake8 bin/probert --ignore=F403
-	flake8 --exclude probert/tests/ probert --ignore=F403
-
-unit:
-	echo "Running unit tests..."
-	python3 -m "nose" -v --nologcapture --with-coverage probert/tests/
+test:
+	tox

--- a/probert/network.py
+++ b/probert/network.py
@@ -24,7 +24,11 @@ import socket
 
 import pyudev
 
-from probert import _nl80211, _rtnetlink
+try:
+    from probert import _nl80211, _rtnetlink
+except ImportError:
+    pass
+
 from probert.utils import udev_get_attributes
 
 log = logging.getLogger('probert.network')
@@ -448,8 +452,9 @@ class Link:
     # This is the logic ip from iproute2 uses to determine whether
     # to show NO-CARRIER or not. It only really makes sense for a
     # wired connection.
-    is_connected = (property(lambda self: ((not (self.flags & IFF_UP)) or
-                                           (self.flags & IFF_RUNNING))))
+    is_connected = (
+        property(lambda self: (
+            (not (self.flags & IFF_UP)) or (self.flags & IFF_RUNNING))))
     is_virtual = (
         property(lambda self: self.devpath.startswith('/devices/virtual/')))
 

--- a/probert/network.py
+++ b/probert/network.py
@@ -24,14 +24,14 @@ import socket
 
 import pyudev
 
-try:
-    from probert import _nl80211, _rtnetlink
-except ImportError:
-    pass
-
 from probert.utils import udev_get_attributes
 
 log = logging.getLogger('probert.network')
+
+try:
+    from probert import _nl80211, _rtnetlink
+except ImportError as e:
+    log.warning('Failed import network library modules: %s', e)
 
 # Standard interface flags (net/if.h)
 IFF_UP = 0x1                   # Interface is up.

--- a/probert/tests/test_prober.py
+++ b/probert/tests/test_prober.py
@@ -1,12 +1,9 @@
 import testtools
-import json
-import argparse
 from unittest.mock import patch
 
 from probert.prober import Prober
 from probert.storage import Storage
 from probert.network import NetworkProber
-from probert.tests.fakes import FAKE_PROBE_ALL_JSON
 
 
 class ProbertTestProber(testtools.TestCase):

--- a/probert/tests/test_storage.py
+++ b/probert/tests/test_storage.py
@@ -53,7 +53,10 @@ class ProbertTestStorageInfo(testtools.TestCase):
             'vendor': 'SanDisk',
             'model': 'SanDisk_SD5SG2128G1052E',
             'serial': 'SanDisk_SD5SG2128G1052E_133507400177',
-            'devpath': '/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda',
+            'devpath': (
+                '/devices/pci0000:00/0000:00:1f.2/ata1/'
+                'host0/target0:0:0/0:0:0:0/block/sda'
+            ),
             'is_virtual': False,
             'raw': sda.get('/dev/sda')
         }

--- a/probert/tests/test_utils.py
+++ b/probert/tests/test_utils.py
@@ -2,6 +2,7 @@ import testtools
 
 from probert import utils
 
+
 class ProbertTestUtils(testtools.TestCase):
     def setUp(self):
         super(ProbertTestUtils, self).setUp()

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -233,7 +233,7 @@ def read_sys_block_size(device):
 
     logsize_base = device_dir
     if not os.path.exists(os.path.join(device_dir, 'queue')):
-        parent_dev = os.path.basename(re.split('[\d+]', device)[0])
+        parent_dev = os.path.basename(re.split(r'[\d+]', device)[0])
         logsize_base = os.path.join('/sys/class/block', parent_dev)
 
     logical_size = os.path.join(logsize_base, 'queue', 'logical_block_size')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+flake8
+pytest
+pytest-cov
+testtools

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py3, flake8
+recreate = true
+skipsdist = true
+
+[testenv]
+deps =
+    -rrequirements.txt
+    -rtest-requirements.txt
+commands =
+    py3: py.test --cov probert probert
+    flake8: flake8 probert bin/probert


### PR DESCRIPTION
This adds a `make test` target that will execute tox. Tox in turn will
run py.test and flake8 against the repo.

Two fixes to the actual code to clean up flake8 issues, one change
to the network.py import around c-bindings so we do not have to build
the package for testing, and a few changes to test code to ensure
pylint passes. I choose this to speed up test/dev, rather than needing
deps and building.

Fixes #63