### PR TITLE
probert.raid: only report devices with DEVTYPE=disk as raids

### DIFF
--- a/probert/raid.py
+++ b/probert/raid.py
@@ -112,7 +112,7 @@ def probe(context=None, report=False):
 
     raids = {}
     for device in context.list_devices(subsystem='block'):
-        if 'MD_NAME' in device:
+        if 'MD_NAME' in device and device.get('DEVTYPE') == 'disk':
             devname = device['DEVNAME']
             attrs = udev_get_attributes(device)
             attrs['size'] = str(read_sys_block_size(devname))


### PR DESCRIPTION
Otherwise partitions of raids end up being reported as full RAID devices
and life is very confusing.