### PR TITLE
fix segfault when a netdev disappears

### DIFF
--- a/probert/_rtnetlinkmodule.c
+++ b/probert/_rtnetlinkmodule.c
@@ -76,6 +76,10 @@ static void observe_link_change(
 	int is_vlan, ifindex;
 	unsigned int flags;
 
+	if (act == NL_ACT_DEL) {
+		link = old_link;
+	}
+
 	is_vlan = rtnl_link_is_vlan(link);
 	ifindex = rtnl_link_get_ifindex(link);
 	flags = rtnl_link_get_flags(link);


### PR DESCRIPTION
new_link is NULL in the v2 callback for a DEL action