### PR TITLE
Add packaging fixes to debian dir

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,8 +14,8 @@ Build-Depends: debhelper (>= 9),
                python3-coverage,
                python3-flake8,
                python3-jsonschema,
-               python3-nose,
                python3-mock,
+               python3-nose,
                python3-pyudev,
                python3-setuptools,
                python3-testtools
@@ -26,7 +26,7 @@ Vcs-Git: https://github.com/CanonicalLtd/probert.git
 
 Package: probert
 Architecture: all
-Depends: ${misc:Depends}, probert-storage, probert-network
+Depends: probert-network, probert-storage, ${misc:Depends}
 Description: Hardware probing tool - metapackage
  This package provides a tool for probing host hardware information
  and emitting a JSON report.
@@ -35,9 +35,7 @@ Description: Hardware probing tool - metapackage
 
 Package: probert-common
 Architecture: all
-Depends: ${misc:Depends},
-         ${python3:Depends},
-         ${shlibs:Depends}
+Depends: ${misc:Depends}, ${python3:Depends}, ${shlibs:Depends}
 Breaks: probert (<< 0.0.16)
 Replaces: probert (<< 0.0.16)
 Description: Hardware probing tool - common
@@ -48,11 +46,11 @@ Description: Hardware probing tool - common
 
 Package: probert-storage
 Architecture: all
-Depends: probert-common (= ${source:Version}),
-         bcache-tools,
+Depends: bcache-tools,
          lvm2,
          mdadm,
          multipath-tools,
+         probert-common (= ${source:Version}),
          s390-tools [s390x],
          zfsutils-linux,
          ${misc:Depends},

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,7 @@ Description: Hardware probing tool - common
  This package provides the common code for probing.
 
 Package: probert-storage
-Architecture: all
+Architecture: any
 Depends: bcache-tools,
          lvm2,
          mdadm,

--- a/debian/probert-common.install
+++ b/debian/probert-common.install
@@ -7,9 +7,12 @@ usr/lib/python3.*/dist-packages/probert/__init__.py
 usr/lib/python3.*/dist-packages/probert/log.py
 usr/lib/python3.*/dist-packages/probert/prober.py
 usr/lib/python3.*/dist-packages/probert/tests/__init__.py
+usr/lib/python3.*/dist-packages/probert/tests/data/dasdd.view
+usr/lib/python3.*/dist-packages/probert/tests/data/dasde.view
 usr/lib/python3.*/dist-packages/probert/tests/data/fake_probe_all.json
 usr/lib/python3.*/dist-packages/probert/tests/fakes.py
 usr/lib/python3.*/dist-packages/probert/tests/helpers.py
+usr/lib/python3.*/dist-packages/probert/tests/test_dasd.py
 usr/lib/python3.*/dist-packages/probert/tests/test_lvm.py
 usr/lib/python3.*/dist-packages/probert/tests/test_multipath.py
 usr/lib/python3.*/dist-packages/probert/tests/test_prober.py

--- a/debian/probert-common.install
+++ b/debian/probert-common.install
@@ -1,18 +1,18 @@
 usr/bin/probert usr/share/probert/bin
-usr/lib/python3.*/dist-packages/probert-*.egg-info/requires.txt
-usr/lib/python3.*/dist-packages/probert-*.egg-info/dependency_links.txt
 usr/lib/python3.*/dist-packages/probert-*.egg-info/PKG-INFO
+usr/lib/python3.*/dist-packages/probert-*.egg-info/dependency_links.txt
+usr/lib/python3.*/dist-packages/probert-*.egg-info/requires.txt
 usr/lib/python3.*/dist-packages/probert-*.egg-info/top_level.txt
-usr/lib/python3.*/dist-packages/probert/log.py
-usr/lib/python3.*/dist-packages/probert/utils.py
-usr/lib/python3.*/dist-packages/probert/prober.py
 usr/lib/python3.*/dist-packages/probert/__init__.py
-usr/lib/python3.*/dist-packages/probert/tests/test_utils.py
+usr/lib/python3.*/dist-packages/probert/log.py
+usr/lib/python3.*/dist-packages/probert/prober.py
+usr/lib/python3.*/dist-packages/probert/tests/__init__.py
 usr/lib/python3.*/dist-packages/probert/tests/data/fake_probe_all.json
 usr/lib/python3.*/dist-packages/probert/tests/fakes.py
-usr/lib/python3.*/dist-packages/probert/tests/test_storage.py
-usr/lib/python3.*/dist-packages/probert/tests/test_lvm.py
-usr/lib/python3.*/dist-packages/probert/tests/__init__.py
 usr/lib/python3.*/dist-packages/probert/tests/helpers.py
+usr/lib/python3.*/dist-packages/probert/tests/test_lvm.py
 usr/lib/python3.*/dist-packages/probert/tests/test_multipath.py
 usr/lib/python3.*/dist-packages/probert/tests/test_prober.py
+usr/lib/python3.*/dist-packages/probert/tests/test_storage.py
+usr/lib/python3.*/dist-packages/probert/tests/test_utils.py
+usr/lib/python3.*/dist-packages/probert/utils.py

--- a/debian/probert-network.install
+++ b/debian/probert-network.install
@@ -1,5 +1,5 @@
-usr/lib/python3.*/dist-packages/probert/_nl80211module.c
-usr/lib/python3.*/dist-packages/probert/network.py
-usr/lib/python3.*/dist-packages/probert/_rtnetlinkmodule.c
 usr/lib/python3.*/dist-packages/probert/_nl80211.*.so
+usr/lib/python3.*/dist-packages/probert/_nl80211module.c
 usr/lib/python3.*/dist-packages/probert/_rtnetlink.*.so
+usr/lib/python3.*/dist-packages/probert/_rtnetlinkmodule.c
+usr/lib/python3.*/dist-packages/probert/network.py

--- a/debian/probert-storage.install
+++ b/debian/probert-storage.install
@@ -1,9 +1,9 @@
-usr/lib/python3.*/dist-packages/probert/raid.py
-usr/lib/python3.*/dist-packages/probert/multipath.py
-usr/lib/python3.*/dist-packages/probert/zfs.py
 usr/lib/python3.*/dist-packages/probert/bcache.py
-usr/lib/python3.*/dist-packages/probert/lvm.py
 usr/lib/python3.*/dist-packages/probert/dmcrypt.py
-usr/lib/python3.*/dist-packages/probert/storage.py
-usr/lib/python3.*/dist-packages/probert/mount.py
 usr/lib/python3.*/dist-packages/probert/filesystem.py
+usr/lib/python3.*/dist-packages/probert/lvm.py
+usr/lib/python3.*/dist-packages/probert/mount.py
+usr/lib/python3.*/dist-packages/probert/multipath.py
+usr/lib/python3.*/dist-packages/probert/raid.py
+usr/lib/python3.*/dist-packages/probert/storage.py
+usr/lib/python3.*/dist-packages/probert/zfs.py

--- a/debian/probert-storage.install
+++ b/debian/probert-storage.install
@@ -1,4 +1,5 @@
 usr/lib/python3.*/dist-packages/probert/bcache.py
+usr/lib/python3.*/dist-packages/probert/dasd.py
 usr/lib/python3.*/dist-packages/probert/dmcrypt.py
 usr/lib/python3.*/dist-packages/probert/filesystem.py
 usr/lib/python3.*/dist-packages/probert/lvm.py


### PR DESCRIPTION
In other projects we maintain branches with just the ubuntu packaging. This allows us to merge new upstream snapshots quickly and maintain release deltas in these branches if needed.