### PR TITLE
multipath: use non-whitespace to split output

### DIFF
--- a/probert/multipath.py
+++ b/probert/multipath.py
@@ -25,6 +25,7 @@ MPATH_SHOW = {
     'paths': MPath,
     'maps': MMap,
 }
+MP_SEP = ','
 
 log = logging.getLogger('probert.multipath')
 
@@ -43,7 +44,7 @@ def _extract_mpath_data(cmd, show_verb):
     for line in data.splitlines():
         mp_dict = None
         try:
-            field_vals = line.split()
+            field_vals = line.split(MP_SEP)
             log.debug('Extracted multipath %s fields: %s',
                       show_verb, field_vals)
             mp_dict = mptype(*field_vals)._asdict()
@@ -58,13 +59,13 @@ def _extract_mpath_data(cmd, show_verb):
 
 
 def multipath_show_paths():
-    path_format = "%d %z %m %N %n %R %r %a"
+    path_format = MP_SEP.join(["%d", "%z", "%m", "%N", "%n", "%R", "%r", "%a"])
     cmd = ['multipathd', 'show', 'paths', 'raw', 'format', path_format]
     return _extract_mpath_data(cmd, 'paths')
 
 
 def multipath_show_maps():
-    maps_format = "%w %d %N"
+    maps_format = MP_SEP.join(["%w", "%d", "%N"])
     cmd = ['multipathd', 'show', 'maps', 'raw', 'format', maps_format]
     return _extract_mpath_data(cmd, 'maps')
 

--- a/probert/tests/test_multipath.py
+++ b/probert/tests/test_multipath.py
@@ -5,54 +5,76 @@ import testtools
 from probert import multipath
 from probert.tests.helpers import random_string
 
+MP_SEP = multipath.MP_SEP
+
 
 class TestMultipath(testtools.TestCase):
 
     @mock.patch('probert.multipath.subprocess.run')
     def test_multipath_show_paths(self, m_run):
-        mp_out = " ".join([random_string() for x in range(0, 8)])
+        mp_out = MP_SEP.join([random_string() for x in range(0, 8)])
         cp = subprocess.CompletedProcess(args=['foo'], returncode=0,
                                          stdout=mp_out.encode('utf-8'),
                                          stderr="")
         m_run.return_value = cp
-        expected_result = [multipath.MPath(*mp_out.split())._asdict()]
+        expected_result = [multipath.MPath(*mp_out.split(MP_SEP))._asdict()]
+        result = multipath.multipath_show_paths()
+        self.assertEqual(expected_result, result)
+
+    @mock.patch('probert.multipath.subprocess.run')
+    def test_multipath_show_paths_serial_with_spaces(self, m_run):
+        mp_out = MP_SEP.join(['sda', 'IPR-0 1234567890'] +
+                             [random_string() for x in range(0, 6)])
+        cp = subprocess.CompletedProcess(args=['foo'], returncode=0,
+                                         stdout=mp_out.encode('utf-8'),
+                                         stderr="")
+        m_run.return_value = cp
+        expected_result = [multipath.MPath(*mp_out.split(MP_SEP))._asdict()]
         result = multipath.multipath_show_paths()
         self.assertEqual(expected_result, result)
 
     @mock.patch('probert.multipath.subprocess.run')
     def test_multipath_show_paths_skips_unparsable_output(self, m_run):
-        lines = ["1 2 3 4 5 6 7 8", "", "a b c d e f g h"]
+        lines = [
+            MP_SEP.join([random_string() for x in range(0, 8)]),
+            "",
+            MP_SEP.join([random_string() for x in range(0, 8)]),
+        ]
         mp_out = "\n".join(lines)
         cp = subprocess.CompletedProcess(args=['foo'], returncode=0,
                                          stdout=mp_out.encode('utf-8'),
                                          stderr="")
         m_run.return_value = cp
-        expected_result = [multipath.MPath(*lines[0].split())._asdict(),
-                           multipath.MPath(*lines[2].split())._asdict()]
+        expected_result = [multipath.MPath(*lines[0].split(MP_SEP))._asdict(),
+                           multipath.MPath(*lines[2].split(MP_SEP))._asdict()]
         result = multipath.multipath_show_paths()
         self.assertEqual(expected_result, result)
 
     @mock.patch('probert.multipath.subprocess.run')
     def test_multipath_show_maps(self, m_run):
-        mp_out = " ".join([random_string() for x in range(0, 3)])
+        mp_out = MP_SEP.join([random_string() for x in range(0, 3)])
         cp = subprocess.CompletedProcess(args=['foo'], returncode=0,
                                          stdout=mp_out.encode('utf-8'),
                                          stderr="")
         m_run.return_value = cp
-        expected_result = [multipath.MMap(*mp_out.split())._asdict()]
+        expected_result = [multipath.MMap(*mp_out.split(MP_SEP))._asdict()]
         result = multipath.multipath_show_maps()
         self.assertEqual(expected_result, result)
 
     @mock.patch('probert.multipath.subprocess.run')
     def test_multipath_show_maps_skips_unparsable_output(self, m_run):
-        lines = ["1 2 3", "", "a b c"]
+        lines = [
+            MP_SEP.join([random_string() for x in range(0, 3)]),
+            "",
+            MP_SEP.join([random_string() for x in range(0, 3)]),
+        ]
         mp_out = "\n".join(lines)
         cp = subprocess.CompletedProcess(args=['foo'], returncode=0,
                                          stdout=mp_out.encode('utf-8'),
                                          stderr="")
         m_run.return_value = cp
-        expected_result = [multipath.MMap(*lines[0].split())._asdict(),
-                           multipath.MMap(*lines[2].split())._asdict()]
+        expected_result = [multipath.MMap(*lines[0].split(MP_SEP))._asdict(),
+                           multipath.MMap(*lines[2].split(MP_SEP))._asdict()]
         result = multipath.multipath_show_maps()
         self.assertEqual(expected_result, result)
 
@@ -66,10 +88,10 @@ class TestMultipath(testtools.TestCase):
     @mock.patch('probert.multipath.multipath_show_paths')
     @mock.patch('probert.multipath.multipath_show_maps')
     def test_multipath_probe_collects_maps_and_paths(self, m_maps, m_paths):
-        path_string = " ".join([random_string() for x in range(0, 8)])
-        paths = multipath.MPath(*path_string.split())._asdict()
-        maps_string = " ".join([random_string() for x in range(0, 3)])
-        maps = multipath.MMap(*maps_string.split())._asdict()
+        path_string = MP_SEP.join([random_string() for x in range(0, 8)])
+        paths = multipath.MPath(*path_string.split(MP_SEP))._asdict()
+        maps_string = MP_SEP.join([random_string() for x in range(0, 3)])
+        maps = multipath.MMap(*maps_string.split(MP_SEP))._asdict()
         m_maps.return_value = [maps]
         m_paths.return_value = [paths]
         result = multipath.probe()


### PR DESCRIPTION
Use a non-whitespace separator when generating output from
multipathd, then tokenize the output using the separator, preserving
whitespace in the field, serial, for example.