### PR TITLE
cope with block devices with no MAJOR in udev

### DIFF
--- a/probert/dmcrypt.py
+++ b/probert/dmcrypt.py
@@ -14,8 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import pyudev
 import subprocess
+
+import pyudev
+
+from probert.utils import sane_block_devices
+
 
 log = logging.getLogger('probert.dmcrypt')
 
@@ -54,7 +58,7 @@ def probe(context=None, report=False):
     crypt_devices = {}
 
     # look for block devices with DM_UUID and CRYPT; these are crypt devices
-    for device in context.list_devices(subsystem='block'):
+    for device in sane_block_devices(context):
         if 'DM_UUID' in device and device['DM_UUID'].startswith('CRYPT'):
             devname = device['DEVNAME']
             dm_info = dmsetup_info(devname)

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -34,7 +34,7 @@ def probe(context=None):
     for device in context.list_devices(subsystem='block'):
         # Ignore block major=1 (ramdisk) and major=7 (loopback)
         # these won't ever be used in recreating storage on target systems.
-        if device['MAJOR'] not in ["1", "7"]:
+        if device.get('MAJOR') not in ["1", "7", None]:
             fs_info = get_device_filesystem(device)
             # The ID_FS_ udev values come from libblkid, which contains code to
             # recognize lots of different things that block devices or their

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -14,7 +14,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+
 import pyudev
+
+from probert.utils import sane_block_devices
 
 log = logging.getLogger('probert.filesystems')
 
@@ -31,10 +34,7 @@ def probe(context=None):
     if not context:
         context = pyudev.Context()
 
-    for device in context.list_devices(subsystem='block'):
-        if "MAJOR" not in device:
-            # Shouldn't happen but apparently does! (LP: #1868109)
-            continue
+    for device in sane_block_devices(context):
         # Ignore block major=1 (ramdisk) and major=7 (loopback)
         # these won't ever be used in recreating storage on target systems.
         if device['MAJOR'] not in ["1", "7"]:

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -32,9 +32,12 @@ def probe(context=None):
         context = pyudev.Context()
 
     for device in context.list_devices(subsystem='block'):
+        if "MAJOR" not in device:
+            # Shouldn't happen but apparently does! (LP: #1868109)
+            continue
         # Ignore block major=1 (ramdisk) and major=7 (loopback)
         # these won't ever be used in recreating storage on target systems.
-        if device.get('MAJOR') not in ["1", "7", None]:
+        if device['MAJOR'] not in ["1", "7"]:
             fs_info = get_device_filesystem(device)
             # The ID_FS_ udev values come from libblkid, which contains code to
             # recognize lots of different things that block devices or their

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -16,10 +16,14 @@
 import logging
 import json
 import os
-import pyudev
 import subprocess
 
-from probert.utils import read_sys_block_size_bytes
+import pyudev
+
+from probert.utils import (
+    read_sys_block_size_bytes,
+    sane_block_devices,
+    )
 
 log = logging.getLogger('probert.lvm')
 
@@ -204,7 +208,7 @@ def probe(context=None):
     pvols = {}
     vg_report = probe_vgs_report()
 
-    for device in context.list_devices(subsystem='block'):
+    for device in sane_block_devices(context):
         if 'DM_UUID' in device and device['DM_UUID'].startswith('LVM'):
             (lv_id, new_lv) = extract_lvm_partition(device)
             if lv_id not in lvols:

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -14,11 +14,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import pyudev
 import subprocess
 
-from probert.utils import (read_sys_block_size_bytes,
-                           udev_get_attributes)
+import pyudev
+
+from probert.utils import (
+    read_sys_block_size_bytes,
+    sane_block_devices,
+    udev_get_attributes,
+    )
+
 
 log = logging.getLogger('probert.raid')
 
@@ -111,7 +116,7 @@ def probe(context=None, report=False):
     context = pyudev.Context()
 
     raids = {}
-    for device in context.list_devices(subsystem='block'):
+    for device in sane_block_devices(context):
         if 'MD_NAME' in device and device.get('DEVTYPE') == 'disk':
             devname = device['DEVNAME']
             attrs = udev_get_attributes(device)

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -112,7 +112,10 @@ def blockdev_probe(context=None):
 
     blockdev = {}
     for device in context.list_devices(subsystem='block'):
-        if device.get('MAJOR') not in ["1", "7", None]:
+        if "MAJOR" not in device:
+            # Shouldn't happen but apparently does! (LP: #1868109)
+            continue
+        if device['MAJOR'] not in ["1", "7"]:
             attrs = udev_get_attributes(device)
             # update the size attr as it may only be the number
             # of blocks rather than size in bytes.

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -18,7 +18,11 @@ import logging
 import pyudev
 import subprocess
 
-from probert.utils import udev_get_attributes, read_sys_block_size_bytes
+from probert.utils import (
+    read_sys_block_size_bytes,
+    sane_block_devices,
+    udev_get_attributes,
+    )
 from probert import (bcache, dasd, dmcrypt, filesystem, lvm, mount, multipath,
                      raid, zfs)
 
@@ -111,10 +115,7 @@ def blockdev_probe(context=None):
         context = pyudev.Context()
 
     blockdev = {}
-    for device in context.list_devices(subsystem='block'):
-        if "MAJOR" not in device:
-            # Shouldn't happen but apparently does! (LP: #1868109)
-            continue
+    for device in sane_block_devices(context):
         if device['MAJOR'] not in ["1", "7"]:
             attrs = udev_get_attributes(device)
             # update the size attr as it may only be the number

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -112,7 +112,7 @@ def blockdev_probe(context=None):
 
     blockdev = {}
     for device in context.list_devices(subsystem='block'):
-        if device['MAJOR'] not in ["1", "7"]:
+        if device.get('MAJOR') not in ["1", "7", None]:
             attrs = udev_get_attributes(device)
             # update the size attr as it may only be the number
             # of blocks rather than size in bytes.

--- a/probert/tests/test_lvm.py
+++ b/probert/tests/test_lvm.py
@@ -264,12 +264,13 @@ class TestLvm(testtools.TestCase):
     @mock.patch('probert.lvm.read_sys_block_size_bytes')
     @mock.patch('probert.lvm.activate_volgroups')
     @mock.patch('probert.lvm.lvm_scan')
-    @mock.patch('probert.lvm.pyudev.Context.list_devices')
+    @mock.patch('probert.lvm.sane_block_devices')
     @mock.patch('probert.lvm.probe_vgs_report')
-    def test_probe(self, m_vgs, m_pyudev, m_scan, m_activate, m_size, m_run):
+    def test_probe(self, m_vgs, m_blockdevs, m_scan, m_activate, m_size,
+                   m_run):
         size = 1000
         m_size.return_value = size
-        m_pyudev.return_value = CONTEXT
+        m_blockdevs.return_value = CONTEXT
         m_vgs.return_value = VGS_REPORT
 
         expected_result = {
@@ -297,13 +298,13 @@ class TestLvm(testtools.TestCase):
     @mock.patch('probert.lvm.read_sys_block_size_bytes')
     @mock.patch('probert.lvm.activate_volgroups')
     @mock.patch('probert.lvm.lvm_scan')
-    @mock.patch('probert.lvm.pyudev.Context.list_devices')
+    @mock.patch('probert.lvm.sane_block_devices')
     @mock.patch('probert.lvm.probe_vgs_report')
-    def test_probe_skip_dupes(self, m_vgs, m_pyudev, m_scan, m_activate,
+    def test_probe_skip_dupes(self, m_vgs, m_blockdevs, m_scan, m_activate,
                               m_size, m_run):
         size = 1000
         m_size.return_value = size
-        m_pyudev.return_value = CONTEXT_DUPES
+        m_blockdevs.return_value = CONTEXT_DUPES
         m_vgs.return_value = VGS_REPORT_DUPES
 
         expected_result = {

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -242,3 +242,11 @@ def read_sys_block_size_bytes(device):
 def read_sys_block_slaves(device):
     device_dir = os.path.join('/sys/class/block', os.path.basename(device))
     return os.listdir(os.path.join(device_dir, 'slaves'))
+
+
+def sane_block_devices(context):
+    for device in context.list_devices(subsystem='block'):
+        if "MAJOR" not in device:
+            # Shouldn't happen but apparently does! (LP: #1868109)
+            continue
+        yield device


### PR DESCRIPTION
https://bugs.launchpad.net/subiquity/+bug/1868109 reports a crash
stemming from a block device that has no MAJOR in udev. I'm not sure
what that represents, but crashing probably isn't the correct response.
Ignore such devices instead.